### PR TITLE
fix: 기본 로그인 기능 추가

### DIFF
--- a/spring-rest-member/src/main/java/com/dife/member/config/SecurityConfig.java
+++ b/spring-rest-member/src/main/java/com/dife/member/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(requests -> {
                     requests.requestMatchers("/api/members/register").permitAll();
+                    requests.requestMatchers("/api/members/login").permitAll();
                     requests.requestMatchers("/api/**").authenticated();
                 })
                 .build();

--- a/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
+++ b/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.dife.member.controller;
 
 
 import com.dife.member.model.Member;
+import com.dife.member.model.dto.LoginDto;
 import com.dife.member.model.dto.MemberUpdateDto;
 import com.dife.member.model.RegisterRequestDto;
 import com.dife.member.repository.MemberRepository;
@@ -50,4 +51,11 @@ public class MemberController {
         this.memberService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED).body("유저가 생성되었습니다.");
     }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(@RequestBody LoginDto request) {
+        Member member = memberService.login(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(member.getEmail() + "유저가 로그인했습니다.");
+    }
+
 }

--- a/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
+++ b/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.dife.member.service;
 
 import com.dife.member.model.Member;
+import com.dife.member.model.dto.LoginDto;
 import com.dife.member.model.dto.MemberUpdateDto;
 import com.dife.member.repository.MemberRepository;
 import com.dife.member.model.RegisterRequestDto;
@@ -28,6 +29,19 @@ public class MemberService {
         member.setPassword(encodedPassword);
 
         memberRepository.save(member);
+    }
+
+    public Member login(LoginDto dto)
+    {
+        Optional<Member> optionalMember = memberRepository.findByEmail(dto.getEmail());
+
+        if (optionalMember.isEmpty())
+        {
+            throw new IllegalStateException("존재하지 않는 회원입니다.");
+        }
+
+        Member member = optionalMember.get();
+        return member;
     }
 
     @Transactional


### PR DESCRIPTION
### 기본 로그인 기능
- 레포지토리를 이용해 이메일로 회원 찾아 로그인함

#### [postman 테스트]
테스트에 앞서 DB에 정보가 들어있지 않아야 함 
서버가 켜질 때마다 DB는 초기화됨

DB 명령어
- use DB명 (dife_local)
- drop table member;

그 후 서버 재시작 후 포스트맨 실행

register -> login
<img width="761" alt="스크린샷 2024-03-23 오후 7 38 46" src="https://github.com/team-diverse/dife-backend/assets/124496650/7926cba9-a92c-42b1-b5ee-1cd2bdb7e7b9">

