### PR TITLE
ci(member): Member Microservice를 컨테이너화 하자

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.8'
+services:
+  db:
+    container_name: dife-mysql
+    image: mysql:8.0.33
+    restart: always
+    environment:
+      - MYSQL_DATABASE=${DB_NAME}
+      - MYSQL_USER=${DB_USER}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+    ports:
+      - 3307:${DB_PORT}
+
+  member:
+    build:
+      context: ./spring-rest-member
+      dockerfile: Dockerfile
+    restart: always
+    ports:
+      - ${MEMBER_PORT}:${MEMBER_PORT}
+    container_name: dife-spring-rest-member
+    env_file: .env
+    depends_on:
+      - db
+
+networks:
+  default:
+    name: dife

--- a/spring-rest-member/Dockerfile
+++ b/spring-rest-member/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:17-alpine AS builder
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+COPY src src
+RUN chmod +x ./gradlew
+RUN ./gradlew bootJar
+
+FROM openjdk:17-alpine
+COPY --from=builder build/libs/*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "/app.jar"]
+VOLUME /tmp

--- a/spring-rest-member/src/main/resources/application-local.yml
+++ b/spring-rest-member/src/main/resources/application-local.yml
@@ -5,6 +5,6 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul
     username: ${DB_USER}
     password: ${DB_PASSWORD}


### PR DESCRIPTION
### 개요

- 개별 마이크로서비스의 배포가 쉽도록 하기 위해 Containerize하자

### 수정 사항

- Member 마이크로서비스 내에 Dockerfile 생성
  - 빌드를 생성하고 컨테이너에서 활용할 수 있도록 조치

- docker-compose를 활용해서 마이크로서비스에 대한 전체적인 설정을 정의한다.
  - db는 도커의 컨테이너화된 mysql이며, DB 관리가 더 쉬워진다
  - member는 멤버서비스에 대한 설정이다.
  - port는 호스트port:컨테이너port로 이루어지며 로컬에서 혹시라도 3306을 사용할 수 있기 때문에 3307로 맵핑하고 컨테이너 내부에서는 3306을
사용한다.

  - 그리고 .env 파일에서 환경 변수를 가져올 수 있도록 한다.
  - depends on 은 member가 db에 의존하도록 한다

- 위의 변경 사항들에 따라, jdbc URL의 DB_HOST가 변경될 수 있다. DB_HOST를 `localhost`로 사용하면 컴퓨터에 깔린 MySQL을 사용하는 것이고 `db`로 쓰면, 도커의 MySQL에 접근한다.