### PR TITLE
ci(ecs): Docker Image 업로드 및 ECS 컨테이너 업데이트 CI 코드

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy to Amazon ECS
+
+on:
+  push:
+    branches:
+      - prod
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image to ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: dife-ecr
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Retrieve Task Definition ARN
+        id: get-taskdef-arn
+        run: |
+          TASK_DEF_ARN=$(aws cloudformation describe-stacks --stack-name DifeCloudStack --query "Stacks[0].Outputs[?OutputKey=='Ec2TaskDefinitionArn'].OutputValue" --output text)
+          echo "TASK_DEF_ARN=$TASK_DEF_ARN" >> $GITHUB_ENV
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Update ECS Service
+        run: |
+          NEW_TASK_DEF=$(aws ecs update-task-definition --family $(echo $TASK_DEF_ARN | cut -d '/' -f 2) --image ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }} --query "taskDefinition.taskDefinitionArn" --output text)
+          aws ecs update-service --cluster dife-cluster --service MemberService --task-definition "$NEW_TASK_DEF"
+        env:
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+


### PR DESCRIPTION
### 개요

- prod 브랜치로 코드가 push가 되면, 현재 코드를 Docker Image로 만들어서 그것을 AWS ECR에 올린다.
- 그 다음 ECR의 이미지를 활용해서 ECS의 컨테이너로 배포한다.

### 수정 사항

- 참고로, Docker Image에 현재 Commit hash를 tag로 달고 latest를 tag로 달아서 최신 이미지를 서비스로 배포할 수 있도록하고 트래킹이 될 수 있도록
한다.

- Task Definition은 컨테이너에 대한 간단한 세팅으로 DifeCloudStack에서 정의한 것을 바탕으로 aws cli를 이용해서 자동으로 가져오게 된다.

- 그것을 바탕으로 ecs update-service를 한다