### PR TITLE
Refactor/member jwtlogin

### DIFF
--- a/spring-rest-member/build.gradle
+++ b/spring-rest-member/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	
 	implementation 'org.modelmapper:modelmapper:3.2.0'
 }

--- a/spring-rest-member/src/main/java/com/dife/member/ExceptionResonse.java
+++ b/spring-rest-member/src/main/java/com/dife/member/ExceptionResonse.java
@@ -1,0 +1,12 @@
+package com.dife.member;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ExceptionResonse {
+
+    private final String exceptionMessage;
+}

--- a/spring-rest-member/src/main/java/com/dife/member/GlobalExceptionHandler.java
+++ b/spring-rest-member/src/main/java/com/dife/member/GlobalExceptionHandler.java
@@ -1,0 +1,73 @@
+package com.dife.member;
+
+import com.dife.member.exception.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<ExceptionResonse> handleMemberException(MemberException exception)
+    {
+        return ResponseEntity
+                .status(INTERNAL_SERVER_ERROR.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ExceptionResonse> handleNotFoundException(NotFoundException exception)
+    {
+        return ResponseEntity
+                .status(NOT_FOUND.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<?> handleBadRequestException(BadRequestException exception)
+    {
+        return ResponseEntity
+                .status(BAD_REQUEST.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(DuplicateException.class)
+    public ResponseEntity<ExceptionResonse> handleDuplicateException(DuplicateException exception)
+    {
+        return ResponseEntity
+                .status(CONFLICT.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ExceptionResonse> handleForbiddenException(ForbiddenException exception)
+    {
+        return ResponseEntity
+                .status(FORBIDDEN.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+    @ExceptionHandler(UnAuthorizationException.class)
+    public ResponseEntity<ExceptionResonse> handleUnAuthorizationException(UnAuthorizationException exception)
+    {
+        return ResponseEntity
+                .status(UNAUTHORIZED.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResonse> handleException(Exception exception)
+    {
+        return ResponseEntity
+                .status(INTERNAL_SERVER_ERROR.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+
+}

--- a/spring-rest-member/src/main/java/com/dife/member/config/SecurityConfig.java
+++ b/spring-rest-member/src/main/java/com/dife/member/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.dife.member.config;
 import com.dife.member.jwt.JWTFilter;
 import com.dife.member.jwt.JWTUtil;
 import com.dife.member.jwt.LoginFilter;
+import com.dife.member.repository.MemberRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -15,16 +16,18 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity()
 public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
 
     private final JWTUtil jwtUtil;
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil) {
+    private final MemberRepository memberRepository;
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil, MemberRepository memberRepository) {
 
         this.authenticationConfiguration = authenticationConfiguration;
         this.jwtUtil = jwtUtil;
+        this.memberRepository = memberRepository;
     }
 
     @Bean
@@ -35,27 +38,21 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity
-                .csrf((auth) -> auth.disable());
-        httpSecurity
-                .formLogin((auth) -> auth.disable());
-        httpSecurity
-                .httpBasic((auth) -> auth.disable());
-        httpSecurity
-                .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/api/members/register", "/api/members/login",
-                                "/api/members/**",
-                                "/api/**").permitAll()
-                        .anyRequest().authenticated()
-                );
-        httpSecurity
-                .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);
-        httpSecurity
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class);
-        httpSecurity
-                .sessionManagement((sessionManagement) ->
-                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return httpSecurity
 
-         return httpSecurity.build();
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new JWTFilter(jwtUtil, memberRepository), LoginFilter.class)
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, memberRepository), UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement(
+                        sessionManagement ->
+                                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(requests -> {
+                    requests.requestMatchers("/api/members/register", "/api/members/login").permitAll();
+                    requests.requestMatchers("/api/members/**").authenticated();
+                    requests.requestMatchers("/api/**").authenticated();
+                })
+                .build();
     }
 }

--- a/spring-rest-member/src/main/java/com/dife/member/config/SecurityConfig.java
+++ b/spring-rest-member/src/main/java/com/dife/member/config/SecurityConfig.java
@@ -1,44 +1,56 @@
 package com.dife.member.config;
 
-import lombok.RequiredArgsConstructor;
+import com.dife.member.jwt.JWTFilter;
+import com.dife.member.jwt.JWTUtil;
+import com.dife.member.jwt.LoginFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
-@RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final AuthenticationConfiguration authenticationConfiguration;
+
+    private final JWTUtil jwtUtil;
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil) {
+
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+
+        return configuration.getAuthenticationManager();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-        return httpSecurity
+         return httpSecurity
 
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
-                .cors(AbstractHttpConfigurer::disable)
-//                .sessionManagement(
-//                        sessionManagement ->
-//                                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-//                )
+                 .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class)
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .sessionManagement(
+                        sessionManagement ->
+                                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
                 .authorizeHttpRequests(requests -> {
                     requests.requestMatchers("/api/members/register").permitAll();
                     requests.requestMatchers("/api/members/login").permitAll();
                     requests.requestMatchers("/api/members/**").permitAll();
                     requests.requestMatchers("/api/**").authenticated();
                 })
-//                .formLogin((formlogin) -> formlogin
-//                        .loginPage("/api/members/login")
-//                        .permitAll()
-//                        .defaultSuccessUrl("/api/members/"))
-
                 .build();
     }
 }

--- a/spring-rest-member/src/main/java/com/dife/member/config/SecurityConfig.java
+++ b/spring-rest-member/src/main/java/com/dife/member/config/SecurityConfig.java
@@ -35,22 +35,27 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
-         return httpSecurity
+        httpSecurity
+                .csrf((auth) -> auth.disable());
+        httpSecurity
+                .formLogin((auth) -> auth.disable());
+        httpSecurity
+                .httpBasic((auth) -> auth.disable());
+        httpSecurity
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/api/members/register", "/api/members/login",
+                                "/api/members/**",
+                                "/api/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+        httpSecurity
+                .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);
+        httpSecurity
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class);
+        httpSecurity
+                .sessionManagement((sessionManagement) ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .csrf(AbstractHttpConfigurer::disable)
-                 .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class)
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class)
-                .sessionManagement(
-                        sessionManagement ->
-                                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
-                .authorizeHttpRequests(requests -> {
-                    requests.requestMatchers("/api/members/register").permitAll();
-                    requests.requestMatchers("/api/members/login").permitAll();
-                    requests.requestMatchers("/api/members/**").permitAll();
-                    requests.requestMatchers("/api/**").authenticated();
-                })
-                .build();
+         return httpSecurity.build();
     }
 }

--- a/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
+++ b/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
@@ -4,7 +4,7 @@ package com.dife.member.controller;
 import com.dife.member.model.Member;
 import com.dife.member.model.dto.LoginDto;
 import com.dife.member.model.dto.MemberUpdateDto;
-import com.dife.member.model.RegisterRequestDto;
+import com.dife.member.model.dto.RegisterRequestDto;
 import com.dife.member.repository.MemberRepository;
 import com.dife.member.service.MemberService;
 import jakarta.validation.Valid;
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-import java.util.Optional;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,11 +45,8 @@ public class MemberController {
     @GetMapping("/{id}")
     public ResponseEntity<String> profile(@PathVariable Long id)
     {
-        Optional<Member> optionalMember = memberRepository.findById(id);
-        Member member = optionalMember.get();
-        String confirm = SecurityContextHolder.getContext().getAuthentication().getName();
-        return ResponseEntity.status(HttpStatus.OK).body(member.getEmail() + "유저 마이페이지입니다.\n유저 소개말 : " + member.getBio()
-                                                            + "\n현재 세션 아이디 : " + confirm);
+        Member member = memberService.viewMember(id);
+        return ResponseEntity.status(HttpStatus.OK).body(member.getEmail() + "유저 마이페이지입니다.\n유저 소개말 : " + member.getBio());
     }
 
     @PutMapping("/{id}")

--- a/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
+++ b/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import java.util.Optional;
 import org.springframework.http.HttpStatus;
@@ -47,7 +48,9 @@ public class MemberController {
     {
         Optional<Member> optionalMember = memberRepository.findById(id);
         Member member = optionalMember.get();
-        return ResponseEntity.status(HttpStatus.OK).body(member.getEmail() + "유저 마이페이지입니다.\n유저 소개말 : " + member.getBio());
+        String confirm = SecurityContextHolder.getContext().getAuthentication().getName();
+        return ResponseEntity.status(HttpStatus.OK).body(member.getEmail() + "유저 마이페이지입니다.\n유저 소개말 : " + member.getBio()
+                                                            + "\n현재 세션 아이디 : " + confirm);
     }
 
     @PutMapping("/{id}")

--- a/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
+++ b/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.dife.member.controller;
 
 
+import com.dife.member.exception.MemberNotFoundException;
 import com.dife.member.jwt.JWTUtil;
 import com.dife.member.model.Member;
 import com.dife.member.model.dto.MemberUpdateDto;
@@ -36,13 +37,20 @@ public class MemberController {
         this.memberService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED).body("유저가 생성되었습니다.");
     }
-
     @GetMapping("/mypage")
     public ResponseEntity<String> profile()
     {
-        String memberEmail = SecurityContextHolder.getContext().getAuthentication().getName();
-        Member member = memberService.getMember(memberEmail);
-        return ResponseEntity.status(HttpStatus.OK).body(member.getEmail() + "유저의 마이페이지 입니다.\n유저 소개말 : " + member.getBio());
+        try
+        {
+            String memberEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+            Member member = memberService.getMember(memberEmail);
+            return ResponseEntity.status(HttpStatus.OK).body(member.getEmail() + "유저의 마이페이지 입니다.\n유저 소개말 :" + member.getBio());
+        }
+        catch (MemberNotFoundException e)
+        {
+            throw new MemberNotFoundException("유저를 찾을 수 없습니다!");
+        }
+
     }
 
     @PutMapping("/mypage")

--- a/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
+++ b/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
@@ -1,8 +1,8 @@
 package com.dife.member.controller;
 
 
+import com.dife.member.jwt.JWTUtil;
 import com.dife.member.model.Member;
-import com.dife.member.model.dto.LoginDto;
 import com.dife.member.model.dto.MemberUpdateDto;
 import com.dife.member.model.dto.RegisterRequestDto;
 import com.dife.member.repository.MemberRepository;
@@ -29,6 +29,7 @@ public class MemberController {
     @Autowired
     private MemberRepository memberRepository;
     private final MemberService memberService;
+    private final JWTUtil jwtUtil;
 
     @PostMapping("/register")
     public ResponseEntity<String> register(@Valid @RequestBody RegisterRequestDto request) {
@@ -36,23 +37,18 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.CREATED).body("유저가 생성되었습니다.");
     }
 
-    @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody LoginDto request) {
-        String tokenId = memberService.login(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body("토큰ID : " + tokenId);
+    @GetMapping("/mypage")
+    public ResponseEntity<String> profile()
+    {
+        String memberEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+        Member member = memberService.getMember(memberEmail);
+        return ResponseEntity.status(HttpStatus.OK).body(member.getEmail() + "유저의 마이페이지 입니다.\n유저 소개말 : " + member.getBio());
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<String> profile(@PathVariable Long id)
+    @PutMapping("/mypage")
+    public ResponseEntity<String> editProfile(@RequestBody MemberUpdateDto memberUpdateDto)
     {
-        Member member = memberService.viewMember(id);
-        return ResponseEntity.status(HttpStatus.OK).body(member.getEmail() + "유저 마이페이지입니다.\n유저 소개말 : " + member.getBio());
-    }
-
-    @PutMapping("/{id}")
-    public ResponseEntity<String> editProfile(@PathVariable Long id, @RequestBody MemberUpdateDto memberUpdateDto)
-    {
-        Member member = memberService.updateMember(id, memberUpdateDto);
+        Member member = memberService.updateMember(memberUpdateDto);
         return ResponseEntity.status(HttpStatus.OK).body(member.getEmail() + "유저 업데이트된 마이페이지입니다.\n유저 소개말 : " + member.getBio());
     }
 

--- a/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
+++ b/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
@@ -38,8 +38,8 @@ public class MemberController {
 
     @PostMapping("/login")
     public ResponseEntity<String> login(@RequestBody LoginDto request) {
-        Member member = memberService.login(request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(member.getEmail() + "유저가 로그인했습니다.");
+        String tokenId = memberService.login(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body("토큰ID : " + tokenId);
     }
 
     @GetMapping("/{id}")

--- a/spring-rest-member/src/main/java/com/dife/member/exception/BadRequestException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/BadRequestException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class BadRequestException extends MemberException{
+
+    public BadRequestException(String message)
+    {
+        super(message);
+    }
+
+    public BadRequestException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public BadRequestException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/DuplicateException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/DuplicateException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class DuplicateException extends MemberException{
+
+    public DuplicateException(String message)
+    {
+        super(message);
+    }
+
+    public DuplicateException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public DuplicateException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/DuplicateMemberException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/DuplicateMemberException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class DuplicateMemberException extends DuplicateException{
+
+    public DuplicateMemberException(String message)
+    {
+        super(message);
+    }
+
+    public DuplicateMemberException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public DuplicateMemberException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/ForbiddenException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/ForbiddenException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class ForbiddenException extends MemberException{
+
+    public ForbiddenException(String message)
+    {
+        super(message);
+    }
+
+    public ForbiddenException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public ForbiddenException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/MemberException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/MemberException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class MemberException extends RuntimeException{
+
+    public MemberException(String message)
+    {
+        super(message);
+    }
+
+    public MemberException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public MemberException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/MemberNotFoundException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/MemberNotFoundException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class MemberNotFoundException extends NotFoundException {
+
+    public MemberNotFoundException(String message)
+    {
+        super(message);
+    }
+
+    public MemberNotFoundException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public MemberNotFoundException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/MemberUnAuthorizationException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/MemberUnAuthorizationException.java
@@ -1,0 +1,20 @@
+package com.dife.member.exception;
+
+
+public class MemberUnAuthorizationException extends UnAuthorizationException {
+
+    public MemberUnAuthorizationException(String message)
+    {
+        super(message);
+    }
+
+    public MemberUnAuthorizationException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public MemberUnAuthorizationException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/NotFoundException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/NotFoundException.java
@@ -1,0 +1,21 @@
+package com.dife.member.exception;
+
+
+public class NotFoundException extends MemberException {
+
+    public NotFoundException(String message)
+    {
+        super(message);
+    }
+
+    public NotFoundException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public NotFoundException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/UnAuthorizationException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/UnAuthorizationException.java
@@ -1,0 +1,20 @@
+package com.dife.member.exception;
+
+
+public class UnAuthorizationException extends MemberException {
+
+    public UnAuthorizationException(String message)
+    {
+        super(message);
+    }
+
+    public UnAuthorizationException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public UnAuthorizationException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/jwt/JWTFilter.java
+++ b/spring-rest-member/src/main/java/com/dife/member/jwt/JWTFilter.java
@@ -1,21 +1,30 @@
 package com.dife.member.jwt;
 
+import com.dife.member.ExceptionResonse;
+import com.dife.member.exception.ForbiddenException;
+import com.dife.member.exception.MemberNotFoundException;
+import com.dife.member.exception.UnAuthorizationException;
 import com.dife.member.model.Member;
 import com.dife.member.model.dto.CustomUserDetails;
 import com.dife.member.repository.MemberRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.UnavailableException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.security.SignatureException;
 import java.util.Optional;
 
 
+@Slf4j
 public class JWTFilter  extends OncePerRequestFilter {
 
     private final JWTUtil jwtUtil;
@@ -32,15 +41,27 @@ public class JWTFilter  extends OncePerRequestFilter {
     {
         String token = jwtUtil.resolveToken(request);
 
-        if (token == null)
+        if (token == null) {
+            log.info("토큰 없음");
+            throw new UnAuthorizationException("회원만 접근 가능합니다!");
+        }
+        log.info("순수 토큰 획득");
+        if (jwtUtil.isExpired(token))
         {
-            filterchain.doFilter(request,response);
-            return;
+            log.info("만료된 토큰");
+            throw new ForbiddenException("만료된 토큰입니다!");
         }
 
+        log.info("토큰 획득 : ");
         String email = jwtUtil.getEmail(token);
+
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
+        if (optionalMember.isEmpty())
+        {
+            throw new MemberNotFoundException("유저를 찾을 수 없습니다!");
+        }
         Member member = optionalMember.get();
+
         CustomUserDetails customUserDetails = new CustomUserDetails(member);
         Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/spring-rest-member/src/main/java/com/dife/member/jwt/JWTFilter.java
+++ b/spring-rest-member/src/main/java/com/dife/member/jwt/JWTFilter.java
@@ -1,0 +1,77 @@
+package com.dife.member.jwt;
+
+import com.dife.member.model.Member;
+import com.dife.member.model.dto.CustomUserDetails;
+import com.dife.member.model.dto.LoginDto;
+import com.dife.member.repository.MemberRepository;
+import com.dife.member.service.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+
+public class JWTFilter  extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+    public JWTFilter(JWTUtil jwtUtil) {
+
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String authorization= request.getHeader("Authorization");
+
+        if (authorization == null || !authorization.startsWith("Bearer "))
+        {
+
+            System.out.println("토큰 없음");
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+
+        System.out.println("인증됨");
+
+        String token = authorization.split(" ")[1];
+
+
+        if (jwtUtil.isExpired(token))
+        {
+
+            System.out.println("토큰 만료됨");
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+
+        String email = jwtUtil.getEmail(token);
+        String role = jwtUtil.getRole(token);
+
+
+        Member member = new Member();
+        member.setEmail(email);
+        member.setPassword("password");
+        member.setIs_public(true);
+        member.setIs_korean(true);
+        member.setRole(role);
+        member.setUsername("username");
+        member.setMajor("major");
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(member);
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+        filterChain.doFilter(request, response);
+    }
+
+
+}

--- a/spring-rest-member/src/main/java/com/dife/member/jwt/JWTUtil.java
+++ b/spring-rest-member/src/main/java/com/dife/member/jwt/JWTUtil.java
@@ -1,6 +1,9 @@
 package com.dife.member.jwt;
 
+import com.dife.member.repository.MemberRepository;
+import com.dife.member.service.CustomUserDetailsService;
 import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -13,11 +16,14 @@ import java.util.Date;
 public class JWTUtil {
 
     private SecretKey secretKey;
+    private CustomUserDetailsService userDetailsService;
+    private MemberRepository memberRepository;
 
-    public JWTUtil(@Value("${jwt.secret}")String secret) {
-
+    public JWTUtil(@Value("${jwt.secret}")String secret, CustomUserDetailsService userDetailsService, MemberRepository memberRepository) {
 
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+        this.userDetailsService = userDetailsService;
+        this.memberRepository = memberRepository;
     }
 
     public String getEmail(String token) {
@@ -35,14 +41,33 @@ public class JWTUtil {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
-    public String createJwt(String email, String role, Long expiredMs) {
+    public String createAccessJwt(String email, String role, Long expiredMs) {
 
-        return Jwts.builder()
+        String token =  Jwts.builder()
                 .claim("email", email)
                 .claim("role", role)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)
                 .compact();
+
+//        Optional<Member> optionalMember = memberRepository.findByEmail(email);
+//        Member member = optionalMember.get();
+//        member.setTokenId(token);
+
+        return token;
     }
+
+    public String resolveToken(HttpServletRequest request)
+    {
+        String authorization= request.getHeader("Authorization");
+        if (authorization != null && authorization.startsWith("Bearer "))
+        {
+            return authorization.split(" ")[1];
+        }
+
+        return null;
+    }
+
+
 }

--- a/spring-rest-member/src/main/java/com/dife/member/jwt/JWTUtil.java
+++ b/spring-rest-member/src/main/java/com/dife/member/jwt/JWTUtil.java
@@ -1,0 +1,48 @@
+package com.dife.member.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+
+    public JWTUtil(@Value("${jwt.secret}")String secret) {
+
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getEmail(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("email", String.class);
+    }
+
+    public String getRole(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String email, String role, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("email", email)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/jwt/JWTUtil.java
+++ b/spring-rest-member/src/main/java/com/dife/member/jwt/JWTUtil.java
@@ -1,5 +1,6 @@
 package com.dife.member.jwt;
 
+import com.dife.member.exception.UnAuthorizationException;
 import com.dife.member.repository.MemberRepository;
 import com.dife.member.service.CustomUserDetailsService;
 import io.jsonwebtoken.Jwts;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import java.security.SignatureException;
 import java.util.Date;
 
 @Component
@@ -37,7 +39,6 @@ public class JWTUtil {
     }
 
     public Boolean isExpired(String token) {
-
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
@@ -58,15 +59,13 @@ public class JWTUtil {
         return token;
     }
 
-    public String resolveToken(HttpServletRequest request)
-    {
+    public String resolveToken(HttpServletRequest request) {
         String authorization= request.getHeader("Authorization");
-        if (authorization != null && authorization.startsWith("Bearer "))
+        if (authorization == null || !authorization.startsWith("Bearer "))
         {
-            return authorization.split(" ")[1];
+            throw new UnAuthorizationException("인증되지 않은 회원입니다!");
         }
-
-        return null;
+        return authorization.split(" ")[1];
     }
 
 

--- a/spring-rest-member/src/main/java/com/dife/member/jwt/LoginFilter.java
+++ b/spring-rest-member/src/main/java/com/dife/member/jwt/LoginFilter.java
@@ -1,0 +1,62 @@
+package com.dife.member.jwt;
+
+import com.dife.member.model.dto.CustomUserDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
+
+    public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil)
+    {
+        this.authenticationManager = authenticationManager;
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        String email = request.getParameter("email");
+        String password = request.getParameter("password");
+
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(email, password, null);
+
+        return authenticationManager.authenticate(authToken);
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        String email = customUserDetails.getUsername();
+
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+
+        String role = auth.getAuthority();
+
+        String token = jwtUtil.createJwt(email, role, 60*60*10L);
+
+        response.addHeader("Authorization", "Bearer " + token);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+        response.setStatus(401);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/jwt/LoginFilter.java
+++ b/spring-rest-member/src/main/java/com/dife/member/jwt/LoginFilter.java
@@ -1,9 +1,14 @@
 package com.dife.member.jwt;
 
+import com.dife.member.model.Member;
 import com.dife.member.model.dto.CustomUserDetails;
+import com.dife.member.repository.MemberRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -11,18 +16,25 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Optional;
+
 
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
     private final JWTUtil jwtUtil;
+    private final MemberRepository memberRepository;
 
-    public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil)
+    public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil, MemberRepository memberRepository)
     {
         this.authenticationManager = authenticationManager;
         this.jwtUtil = jwtUtil;
+        this.memberRepository = memberRepository;
+        this.setFilterProcessesUrl("/api/members/login");
     }
 
     @Override
@@ -31,29 +43,41 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String email = request.getParameter("email");
         String password = request.getParameter("password");
 
-        System.out.println(email);
         UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(email, password, null);
 
         return authenticationManager.authenticate(authToken);
     }
 
     @Override
-    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) throws IOException {
 
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
 
         String email = customUserDetails.getUsername();
 
-
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
         GrantedAuthority auth = iterator.next();
-
         String role = auth.getAuthority();
 
-        String token = jwtUtil.createJwt(email, role, 60*60*10L);
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
+        Member member = optionalMember.get();
+
+        String token = jwtUtil.createAccessJwt(email, role, 24 * 60 * 60 * 1000L);
+        member.setTokenId(token);
+
+        String responseBody = "사용자 TokenID : " + token;
+        ResponseEntity<String> responseEntity = ResponseEntity.status(HttpStatus.CREATED).body(responseBody);
+
+
+        response.setStatus(responseEntity.getStatusCode().value());
+        response.setContentType(MediaType.TEXT_PLAIN_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.toString());
+
+        response.getWriter().write(responseEntity.getBody());
 
         response.addHeader("Authorization", "Bearer " + token);
+
     }
 
     @Override

--- a/spring-rest-member/src/main/java/com/dife/member/jwt/LoginFilter.java
+++ b/spring-rest-member/src/main/java/com/dife/member/jwt/LoginFilter.java
@@ -31,6 +31,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String email = request.getParameter("email");
         String password = request.getParameter("password");
 
+        System.out.println(email);
         UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(email, password, null);
 
         return authenticationManager.authenticate(authToken);

--- a/spring-rest-member/src/main/java/com/dife/member/model/Member.java
+++ b/spring-rest-member/src/main/java/com/dife/member/model/Member.java
@@ -55,4 +55,6 @@ public class Member {
 
     private LocalDateTime last_online;
 
+    private String role;
+
 }

--- a/spring-rest-member/src/main/java/com/dife/member/model/Member.java
+++ b/spring-rest-member/src/main/java/com/dife/member/model/Member.java
@@ -57,4 +57,6 @@ public class Member {
 
     private String role;
 
+    private String tokenId;
+
 }

--- a/spring-rest-member/src/main/java/com/dife/member/model/RegisterRequestDto.java
+++ b/spring-rest-member/src/main/java/com/dife/member/model/RegisterRequestDto.java
@@ -37,4 +37,6 @@ public class RegisterRequestDto {
 
     @NotNull()
     private String password;
+
+    private String role;
 }

--- a/spring-rest-member/src/main/java/com/dife/member/model/dto/CustomUserDetails.java
+++ b/spring-rest-member/src/main/java/com/dife/member/model/dto/CustomUserDetails.java
@@ -1,0 +1,72 @@
+package com.dife.member.model.dto;
+
+import com.dife.member.model.Member;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    public CustomUserDetails(Member member)
+    {
+        this.member = member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+
+            @Override
+            public String getAuthority() {
+
+                return member.getRole();
+            }
+        });
+
+        return collection;
+    }
+    @Override
+    public String getUsername() {
+
+        return member.getEmail();
+    }
+
+    @Override
+    public String getPassword() {
+
+        return member.getPassword();
+    }
+
+
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/model/dto/CustomUserDetails.java
+++ b/spring-rest-member/src/main/java/com/dife/member/model/dto/CustomUserDetails.java
@@ -1,6 +1,8 @@
 package com.dife.member.model.dto;
 
 import com.dife.member.model.Member;
+import lombok.*;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -43,9 +45,6 @@ public class CustomUserDetails implements UserDetails {
 
         return member.getPassword();
     }
-
-
-
     @Override
     public boolean isAccountNonExpired() {
 

--- a/spring-rest-member/src/main/java/com/dife/member/model/dto/LoginDto.java
+++ b/spring-rest-member/src/main/java/com/dife/member/model/dto/LoginDto.java
@@ -16,4 +16,6 @@ public class LoginDto {
 
     @NotNull
     private String password;
+
+    private String role;
 }

--- a/spring-rest-member/src/main/java/com/dife/member/model/dto/MemberUpdateDto.java
+++ b/spring-rest-member/src/main/java/com/dife/member/model/dto/MemberUpdateDto.java
@@ -13,6 +13,8 @@ import lombok.*;
 @NoArgsConstructor
 public class MemberUpdateDto {
 
+    private String email;
+
     @NotNull
     private String password;
 

--- a/spring-rest-member/src/main/java/com/dife/member/model/dto/RegisterRequestDto.java
+++ b/spring-rest-member/src/main/java/com/dife/member/model/dto/RegisterRequestDto.java
@@ -1,4 +1,4 @@
-package com.dife.member.model;
+package com.dife.member.model.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;

--- a/spring-rest-member/src/main/java/com/dife/member/service/CustomUserDetailsService.java
+++ b/spring-rest-member/src/main/java/com/dife/member/service/CustomUserDetailsService.java
@@ -27,7 +27,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         if (optionalMember.isEmpty())
         {
-            return null;
+            throw new UsernameNotFoundException(email + " 유저 못찾음!");
         }
 
         Member member = optionalMember.get();

--- a/spring-rest-member/src/main/java/com/dife/member/service/CustomUserDetailsService.java
+++ b/spring-rest-member/src/main/java/com/dife/member/service/CustomUserDetailsService.java
@@ -1,0 +1,36 @@
+package com.dife.member.service;
+
+import com.dife.member.model.dto.CustomUserDetails;
+import com.dife.member.model.Member;
+import com.dife.member.repository.MemberRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    public CustomUserDetailsService(MemberRepository memberRepository) {
+
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
+
+        if (optionalMember.isEmpty())
+        {
+            Member member = optionalMember.get();
+            return new CustomUserDetails(member);
+        }
+
+        return null;
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/service/CustomUserDetailsService.java
+++ b/spring-rest-member/src/main/java/com/dife/member/service/CustomUserDetailsService.java
@@ -27,10 +27,10 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         if (optionalMember.isEmpty())
         {
-            Member member = optionalMember.get();
-            return new CustomUserDetails(member);
+            return null;
         }
 
-        return null;
+        Member member = optionalMember.get();
+        return new CustomUserDetails(member);
     }
 }

--- a/spring-rest-member/src/main/java/com/dife/member/service/CustomUserDetailsService.java
+++ b/spring-rest-member/src/main/java/com/dife/member/service/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package com.dife.member.service;
 
+import com.dife.member.exception.MemberNotFoundException;
 import com.dife.member.model.dto.CustomUserDetails;
 import com.dife.member.model.Member;
 import com.dife.member.repository.MemberRepository;
@@ -27,7 +28,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         if (optionalMember.isEmpty())
         {
-            throw new UsernameNotFoundException(email + " 유저 못찾음!");
+            throw new MemberNotFoundException(email + " 유저 못찾음!");
         }
 
         Member member = optionalMember.get();

--- a/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
+++ b/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.dife.member.service;
 
+import com.dife.member.jwt.JWTUtil;
 import com.dife.member.model.Member;
 import com.dife.member.model.dto.LoginDto;
 import com.dife.member.model.dto.MemberUpdateDto;
@@ -21,6 +22,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final ModelMapper modelMapper;
     private final BCryptPasswordEncoder passwordEncoder;
+    private final JWTUtil jwtUtil;
 
     public void register(RegisterRequestDto dto) {
         Member member = modelMapper.map(dto, Member.class);
@@ -31,7 +33,7 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public Member login(LoginDto dto)
+    public String login(LoginDto dto)
     {
         Optional<Member> optionalMember = memberRepository.findByEmail(dto.getEmail());
 
@@ -41,7 +43,7 @@ public class MemberService {
         }
 
         Member member = optionalMember.get();
-        return member;
+        return jwtUtil.createJwt(member.getEmail(), member.getRole(), 3000L);
     }
 
     @Transactional

--- a/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
+++ b/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.dife.member.service;
 
+import com.dife.member.exception.DuplicateMemberException;
+import com.dife.member.exception.MemberNotFoundException;
 import com.dife.member.jwt.JWTUtil;
 import com.dife.member.model.Member;
 import com.dife.member.model.dto.LoginDto;
@@ -28,22 +30,22 @@ public class MemberService {
     public void register(RegisterRequestDto dto) {
         Member member = modelMapper.map(dto, Member.class);
 
+        if (memberRepository.existsByEmail(dto.getEmail()))
+        {
+            throw new DuplicateMemberException("이미 등록한 회원입니다!");
+        }
+
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
         member.setPassword(encodedPassword);
 
         memberRepository.save(member);
     }
 
-    public Member getMember(String email)
-    {
+    public Member getMember(String email) {
+
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
-
-        if (optionalMember.isEmpty())
-        {
-            throw new IllegalStateException("존재하지 않는 회원입니다.");
-        }
-
         Member member = optionalMember.get();
+
         return member;
     }
 
@@ -54,7 +56,7 @@ public class MemberService {
 
         if (optionalMember.isEmpty())
         {
-            throw new IllegalStateException("존재하지 않는 회원입니다.");
+            throw new MemberNotFoundException("존재하지 않는 회원입니다.");
         }
 
         Member member = optionalMember.get();

--- a/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
+++ b/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
@@ -8,6 +8,7 @@ import com.dife.member.repository.MemberRepository;
 import com.dife.member.model.dto.RegisterRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,9 +34,9 @@ public class MemberService {
         memberRepository.save(member);
     }
 
-    public String login(LoginDto dto)
+    public Member getMember(String email)
     {
-        Optional<Member> optionalMember = memberRepository.findByEmail(dto.getEmail());
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
 
         if (optionalMember.isEmpty())
         {
@@ -43,26 +44,13 @@ public class MemberService {
         }
 
         Member member = optionalMember.get();
-        return jwtUtil.createJwt(member.getEmail(), member.getRole(), 3000L);
-    }
-
-    public Member viewMember(Long id)
-    {
-        Optional<Member> optionalMember = memberRepository.findById(id);
-
-        if (optionalMember.isEmpty())
-        {
-            throw new IllegalStateException("존재하지 않는 회원입니다.");
-        }
-
-        Member member = optionalMember.get();
-
         return member;
     }
 
-    public Member updateMember(Long id, MemberUpdateDto memberUpdateDto)
+    public Member updateMember(MemberUpdateDto memberUpdateDto)
     {
-        Optional<Member> optionalMember = memberRepository.findById(id);
+        String email = memberUpdateDto.getEmail();
+        Optional<Member> optionalMember = memberRepository.findByEmail(email);
 
         if (optionalMember.isEmpty())
         {

--- a/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
+++ b/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
@@ -5,7 +5,7 @@ import com.dife.member.model.Member;
 import com.dife.member.model.dto.LoginDto;
 import com.dife.member.model.dto.MemberUpdateDto;
 import com.dife.member.repository.MemberRepository;
-import com.dife.member.model.RegisterRequestDto;
+import com.dife.member.model.dto.RegisterRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -46,7 +46,20 @@ public class MemberService {
         return jwtUtil.createJwt(member.getEmail(), member.getRole(), 3000L);
     }
 
-    @Transactional
+    public Member viewMember(Long id)
+    {
+        Optional<Member> optionalMember = memberRepository.findById(id);
+
+        if (optionalMember.isEmpty())
+        {
+            throw new IllegalStateException("존재하지 않는 회원입니다.");
+        }
+
+        Member member = optionalMember.get();
+
+        return member;
+    }
+
     public Member updateMember(Long id, MemberUpdateDto memberUpdateDto)
     {
         Optional<Member> optionalMember = memberRepository.findById(id);

--- a/spring-rest-member/src/main/resources/application.yml
+++ b/spring-rest-member/src/main/resources/application.yml
@@ -8,3 +8,6 @@ spring:
         show-sql: true
         hibernate:
             ddl-auto: create
+
+jwt:
+    secret : vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb

--- a/spring-rest-member/src/test/java/com/dife/member/model/dto/RegisterRequestDtoTest.java
+++ b/spring-rest-member/src/test/java/com/dife/member/model/dto/RegisterRequestDtoTest.java
@@ -1,0 +1,40 @@
+package com.dife.member.model.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RegisterRequestDtoTest {
+
+    @Test
+    void setEmail() {
+    }
+
+    @Test
+    void setStudent_id() {
+    }
+
+    @Test
+    void setUsername() {
+    }
+
+    @Test
+    void setMajor() {
+    }
+
+    @Test
+    void setIs_public() {
+    }
+
+    @Test
+    void setIs_korean() {
+    }
+
+    @Test
+    void setPassword() {
+    }
+
+    @Test
+    void setRole() {
+    }
+}


### PR DESCRIPTION
구현사항
- 기존 JWT로그인 (ACCESS TOKEN만 발급) 구현 동일
- 마이페이지 조회 매핑 수정

TEST 방법
- login 접근시 헤더에 포함되는 Authorization을 갖고와 GET, PUT요청을 해보기


GET요청
<img width="705" alt="스크린샷 2024-03-30 오후 9 24 53" src="https://github.com/team-diverse/dife-backend/assets/124496650/4322927b-add9-439b-b4b0-d32e9389a1e5">


PUT요청
<img width="713" alt="스크린샷 2024-03-30 오후 9 25 18" src="https://github.com/team-diverse/dife-backend/assets/124496650/f9df3247-3a65-47a4-9f40-0b28af1f1f36">



수정사항
- Member 엔티티에 tokenId 추가


### 문제사항
REFRESH TOKEN 발급 구현 시도했던 방법  (결과적으로는 실패)
-> DB에 새로운 ACCESS TOKEN 발급해 저장하는 방법 

- JWTFilter이 작동할 때마다 만료 확인 후 재발급
- memberController에서 GET, PUT 요청에서 만료 확인 후 재발급

디버깅해봤을 때 tokenId가 DB에 저장되는 게 안 찍히는 결과,,, 어디가 문제일까..