### PR TITLE
에러 헨들링 코드 작성

### DIFF
--- a/spring-rest-member/src/main/java/com/dife/member/ExceptionResonse.java
+++ b/spring-rest-member/src/main/java/com/dife/member/ExceptionResonse.java
@@ -1,0 +1,12 @@
+package com.dife.member;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ExceptionResonse {
+
+    private final String exceptionMessage;
+}

--- a/spring-rest-member/src/main/java/com/dife/member/GlobalExceptionHandler.java
+++ b/spring-rest-member/src/main/java/com/dife/member/GlobalExceptionHandler.java
@@ -1,0 +1,73 @@
+package com.dife.member;
+
+import com.dife.member.exception.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<ExceptionResonse> handleMemberException(MemberException exception)
+    {
+        return ResponseEntity
+                .status(INTERNAL_SERVER_ERROR.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ExceptionResonse> handleNotFoundException(NotFoundException exception)
+    {
+        return ResponseEntity
+                .status(NOT_FOUND.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<?> handleBadRequestException(BadRequestException exception)
+    {
+        return ResponseEntity
+                .status(BAD_REQUEST.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(DuplicateException.class)
+    public ResponseEntity<ExceptionResonse> handleDuplicateException(DuplicateException exception)
+    {
+        return ResponseEntity
+                .status(CONFLICT.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ExceptionResonse> handleForbiddenException(ForbiddenException exception)
+    {
+        return ResponseEntity
+                .status(FORBIDDEN.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+    @ExceptionHandler(UnAuthorizationException.class)
+    public ResponseEntity<ExceptionResonse> handleUnAuthorizationException(UnAuthorizationException exception)
+    {
+        return ResponseEntity
+                .status(UNAUTHORIZED.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResonse> handleException(Exception exception)
+    {
+        return ResponseEntity
+                .status(INTERNAL_SERVER_ERROR.value())
+                .body(new ExceptionResonse(exception.getMessage()));
+    }
+
+
+}

--- a/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
+++ b/spring-rest-member/src/main/java/com/dife/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.dife.member.controller;
 
 
+import com.dife.member.exception.MemberNotFoundException;
 import com.dife.member.jwt.JWTUtil;
 import com.dife.member.model.Member;
 import com.dife.member.model.dto.MemberUpdateDto;
@@ -36,13 +37,20 @@ public class MemberController {
         this.memberService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED).body("유저가 생성되었습니다.");
     }
-
     @GetMapping("/mypage")
     public ResponseEntity<String> profile()
     {
-        String memberEmail = SecurityContextHolder.getContext().getAuthentication().getName();
-        Member member = memberService.getMember(memberEmail);
-        return ResponseEntity.status(HttpStatus.OK).body(member.getEmail() + "유저의 마이페이지 입니다.\n유저 소개말 : " + member.getBio());
+        try
+        {
+            String memberEmail = SecurityContextHolder.getContext().getAuthentication().getName();
+            Member member = memberService.getMember(memberEmail);
+            return ResponseEntity.status(HttpStatus.OK).body(member.getEmail() + "유저의 마이페이지 입니다.\n유저 소개말 :" + member.getBio());
+        }
+        catch (MemberNotFoundException e)
+        {
+            throw new MemberNotFoundException("유저를 찾을 수 없습니다!");
+        }
+
     }
 
     @PutMapping("/mypage")

--- a/spring-rest-member/src/main/java/com/dife/member/exception/BadRequestException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/BadRequestException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class BadRequestException extends MemberException{
+
+    public BadRequestException(String message)
+    {
+        super(message);
+    }
+
+    public BadRequestException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public BadRequestException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/DuplicateException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/DuplicateException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class DuplicateException extends MemberException{
+
+    public DuplicateException(String message)
+    {
+        super(message);
+    }
+
+    public DuplicateException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public DuplicateException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/DuplicateMemberException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/DuplicateMemberException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class DuplicateMemberException extends DuplicateException{
+
+    public DuplicateMemberException(String message)
+    {
+        super(message);
+    }
+
+    public DuplicateMemberException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public DuplicateMemberException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/ForbiddenException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/ForbiddenException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class ForbiddenException extends MemberException{
+
+    public ForbiddenException(String message)
+    {
+        super(message);
+    }
+
+    public ForbiddenException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public ForbiddenException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/MemberException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/MemberException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class MemberException extends RuntimeException{
+
+    public MemberException(String message)
+    {
+        super(message);
+    }
+
+    public MemberException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public MemberException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/MemberNotFoundException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/MemberNotFoundException.java
@@ -1,0 +1,19 @@
+package com.dife.member.exception;
+
+public class MemberNotFoundException extends NotFoundException {
+
+    public MemberNotFoundException(String message)
+    {
+        super(message);
+    }
+
+    public MemberNotFoundException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public MemberNotFoundException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/MemberUnAuthorizationException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/MemberUnAuthorizationException.java
@@ -1,0 +1,20 @@
+package com.dife.member.exception;
+
+
+public class MemberUnAuthorizationException extends UnAuthorizationException {
+
+    public MemberUnAuthorizationException(String message)
+    {
+        super(message);
+    }
+
+    public MemberUnAuthorizationException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public MemberUnAuthorizationException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/NotFoundException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/NotFoundException.java
@@ -1,0 +1,21 @@
+package com.dife.member.exception;
+
+
+public class NotFoundException extends MemberException {
+
+    public NotFoundException(String message)
+    {
+        super(message);
+    }
+
+    public NotFoundException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public NotFoundException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+}

--- a/spring-rest-member/src/main/java/com/dife/member/exception/UnAuthorizationException.java
+++ b/spring-rest-member/src/main/java/com/dife/member/exception/UnAuthorizationException.java
@@ -1,0 +1,20 @@
+package com.dife.member.exception;
+
+
+public class UnAuthorizationException extends MemberException {
+
+    public UnAuthorizationException(String message)
+    {
+        super(message);
+    }
+
+    public UnAuthorizationException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    public UnAuthorizationException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/spring-rest-member/src/main/java/com/dife/member/jwt/JWTFilter.java
+++ b/spring-rest-member/src/main/java/com/dife/member/jwt/JWTFilter.java
@@ -1,21 +1,30 @@
 package com.dife.member.jwt;
 
+import com.dife.member.ExceptionResonse;
+import com.dife.member.exception.ForbiddenException;
+import com.dife.member.exception.MemberNotFoundException;
+import com.dife.member.exception.UnAuthorizationException;
 import com.dife.member.model.Member;
 import com.dife.member.model.dto.CustomUserDetails;
 import com.dife.member.repository.MemberRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.UnavailableException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.security.SignatureException;
 import java.util.Optional;
 
 
+@Slf4j
 public class JWTFilter  extends OncePerRequestFilter {
 
     private final JWTUtil jwtUtil;
@@ -32,15 +41,27 @@ public class JWTFilter  extends OncePerRequestFilter {
     {
         String token = jwtUtil.resolveToken(request);
 
-        if (token == null)
+        if (token == null) {
+            log.info("토큰 없음");
+            throw new UnAuthorizationException("회원만 접근 가능합니다!");
+        }
+        log.info("순수 토큰 획득");
+        if (jwtUtil.isExpired(token))
         {
-            filterchain.doFilter(request,response);
-            return;
+            log.info("만료된 토큰");
+            throw new ForbiddenException("만료된 토큰입니다!");
         }
 
+        log.info("토큰 획득 : ");
         String email = jwtUtil.getEmail(token);
+
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
+        if (optionalMember.isEmpty())
+        {
+            throw new MemberNotFoundException("유저를 찾을 수 없습니다!");
+        }
         Member member = optionalMember.get();
+
         CustomUserDetails customUserDetails = new CustomUserDetails(member);
         Authentication authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/spring-rest-member/src/main/java/com/dife/member/jwt/JWTUtil.java
+++ b/spring-rest-member/src/main/java/com/dife/member/jwt/JWTUtil.java
@@ -1,5 +1,6 @@
 package com.dife.member.jwt;
 
+import com.dife.member.exception.UnAuthorizationException;
 import com.dife.member.repository.MemberRepository;
 import com.dife.member.service.CustomUserDetailsService;
 import io.jsonwebtoken.Jwts;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import java.security.SignatureException;
 import java.util.Date;
 
 @Component
@@ -37,7 +39,6 @@ public class JWTUtil {
     }
 
     public Boolean isExpired(String token) {
-
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
     }
 
@@ -58,15 +59,13 @@ public class JWTUtil {
         return token;
     }
 
-    public String resolveToken(HttpServletRequest request)
-    {
+    public String resolveToken(HttpServletRequest request) {
         String authorization= request.getHeader("Authorization");
-        if (authorization != null && authorization.startsWith("Bearer "))
+        if (authorization == null || !authorization.startsWith("Bearer "))
         {
-            return authorization.split(" ")[1];
+            throw new UnAuthorizationException("인증되지 않은 회원입니다!");
         }
-
-        return null;
+        return authorization.split(" ")[1];
     }
 
 

--- a/spring-rest-member/src/main/java/com/dife/member/service/CustomUserDetailsService.java
+++ b/spring-rest-member/src/main/java/com/dife/member/service/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package com.dife.member.service;
 
+import com.dife.member.exception.MemberNotFoundException;
 import com.dife.member.model.dto.CustomUserDetails;
 import com.dife.member.model.Member;
 import com.dife.member.repository.MemberRepository;
@@ -27,7 +28,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         if (optionalMember.isEmpty())
         {
-            throw new UsernameNotFoundException(email + " 유저 못찾음!");
+            throw new MemberNotFoundException(email + " 유저 못찾음!");
         }
 
         Member member = optionalMember.get();

--- a/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
+++ b/spring-rest-member/src/main/java/com/dife/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.dife.member.service;
 
+import com.dife.member.exception.DuplicateMemberException;
+import com.dife.member.exception.MemberNotFoundException;
 import com.dife.member.jwt.JWTUtil;
 import com.dife.member.model.Member;
 import com.dife.member.model.dto.LoginDto;
@@ -28,22 +30,22 @@ public class MemberService {
     public void register(RegisterRequestDto dto) {
         Member member = modelMapper.map(dto, Member.class);
 
+        if (memberRepository.existsByEmail(dto.getEmail()))
+        {
+            throw new DuplicateMemberException("이미 등록한 회원입니다!");
+        }
+
         String encodedPassword = passwordEncoder.encode(dto.getPassword());
         member.setPassword(encodedPassword);
 
         memberRepository.save(member);
     }
 
-    public Member getMember(String email)
-    {
+    public Member getMember(String email) {
+
         Optional<Member> optionalMember = memberRepository.findByEmail(email);
-
-        if (optionalMember.isEmpty())
-        {
-            throw new IllegalStateException("존재하지 않는 회원입니다.");
-        }
-
         Member member = optionalMember.get();
+
         return member;
     }
 
@@ -54,7 +56,7 @@ public class MemberService {
 
         if (optionalMember.isEmpty())
         {
-            throw new IllegalStateException("존재하지 않는 회원입니다.");
+            throw new MemberNotFoundException("존재하지 않는 회원입니다.");
         }
 
         Member member = optionalMember.get();

--- a/spring-rest-member/src/test/java/com/dife/member/model/dto/RegisterRequestDtoTest.java
+++ b/spring-rest-member/src/test/java/com/dife/member/model/dto/RegisterRequestDtoTest.java
@@ -1,0 +1,40 @@
+package com.dife.member.model.dto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RegisterRequestDtoTest {
+
+    @Test
+    void setEmail() {
+    }
+
+    @Test
+    void setStudent_id() {
+    }
+
+    @Test
+    void setUsername() {
+    }
+
+    @Test
+    void setMajor() {
+    }
+
+    @Test
+    void setIs_public() {
+    }
+
+    @Test
+    void setIs_korean() {
+    }
+
+    @Test
+    void setPassword() {
+    }
+
+    @Test
+    void setRole() {
+    }
+}


### PR DESCRIPTION
개요
- 에러 헨들러 코드 작성
- 최상단 RuntimeException에서 원하는 Exception 만들어 가는 구조
- RuntimeException > MemberException : 최상단


이미 등록한 회원 접근 시
<img width="717" alt="스크린샷 2024-03-31 오후 7 13 54" src="https://github.com/team-diverse/dife-backend/assets/124496650/4b2227d9-9ecd-4aec-a797-5e306f7bbdee">
<img width="1127" alt="스크린샷 2024-03-31 오후 6 59 17" src="https://github.com/team-diverse/dife-backend/assets/124496650/28fdf785-25ea-4a49-8022-b7142212baa2">


회원가입 하지 않은 회원이 로그인 접근 시 (커스텀한 LoginFilter 이용)
<img width="694" alt="스크린샷 2024-03-31 오후 7 41 59" src="https://github.com/team-diverse/dife-backend/assets/124496650/ad168b55-b5a6-429c-a80b-251e02420c08">


문제상황
- 커스텀한 JWT로그인 방법에서의 에러 핸들링에서의 오류

- 로그인 하지 않고 GET, PUT요청시의 에러 핸들링을 못하고 있음

@seungholee-dev 
에러 메시지는 찍히는데 에러 해당 메서드가 다른 Exception 또한 던져서 나타나는 오류일까요..?
<img width="1222" alt="스크린샷 2024-03-31 오후 9 06 16" src="https://github.com/team-diverse/dife-backend/assets/124496650/25293fa3-666f-4302-9ee0-08043c590f7e">

