### PR TITLE
refactor: DifeApplication 이름 변경

### DIFF
--- a/rest-api/src/main/java/com/dife/api/DifeApplication.java
+++ b/rest-api/src/main/java/com/dife/api/DifeApplication.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class MemberApplication {
+public class DifeApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(MemberApplication.class, args);
+		SpringApplication.run(DifeApplication.class, args);
 	}
 
 }

--- a/rest-api/src/test/java/com/dife/api/DifeApplicationTests.java
+++ b/rest-api/src/test/java/com/dife/api/DifeApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class MemberApplicationTests {
+class DifeApplicationTests {
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
- Mono로 합쳐짐에 따라, DifeApplication으로 메인 어플리케이션의 이름을 변경한다.

[참고] 

IntelliJ에서 gradle을 새로고침 해주시고 run configuration을 저번처럼 설정해주시면 됩니다 :) 