### PR TITLE
ci(pipeline): Docker를 활용해서 컨테이너화하고 Pipeline 구성

### DIFF
--- a/.github/workflows/deploys.yml
+++ b/.github/workflows/deploys.yml
@@ -1,0 +1,48 @@
+name: Deploy to Amazon ECS
+
+on:
+  push:
+    branches:
+      - prod
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image to ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: dife-ecr
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest ./rest-api
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Deploy to EC2 Instance
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
+          script: |
+            docker stop myapp || true
+            docker rm myapp || true
+            docker pull $ECR_REGISTRY/$ECR_REPOSITORY:latest
+            docker run -d --name myapp -p 8080:8080 $ECR_REGISTRY/$ECR_REPOSITORY:latest

--- a/rest-api/Dockerfile
+++ b/rest-api/Dockerfile
@@ -1,0 +1,14 @@
+FROM openjdk:17-alpine AS builder
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+COPY src src
+RUN chmod +x ./gradlew
+RUN ./gradlew bootJar
+
+FROM openjdk:17-alpine
+COPY --from=builder build/libs/*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "/app.jar"]
+VOLUME /tmp


### PR DESCRIPTION
### 개요

- 현재 개발을 하면, prod로 merge가 되어야 한다.

### 수정 사항

- DockerFile로 Docker를 정의한다.
  - 각종 빌드 파일을 컨테이너에 복사함
  - jar 파일을 실행하도록 구성
  - tmp 폴더를 각종 저장소로 사용

- Github action
  - prod에 병합될 때만 스크립트 돌아가도록 설정
  - AWS credential을 Github Project에 저장된 Secret에서 가져옴
  - ECR로 Docker image를 업로드함
  - EC2에 SSH로 접근하여 해당 Docker 컨테이너를 Run함

### 테스트 방법

- 현재 Merge가 되어야만 작동을 해서 테스트를 할 수 있기 때문에 테스트는 생략합니다! (병합 후 문제 있을 시 수정 예정)
- Merge 이후 ec2주소:8080에 접근하면 접근이 가능해지며, prod에 merge될때마다 업데이트 될 겁니다!