### PR TITLE
fix(ci): 아마존 Region 인식이 되지 않는 버그 수정

### DIFF
--- a/.github/workflows/deploys.yml
+++ b/.github/workflows/deploys.yml
@@ -1,4 +1,4 @@
-name: Deploy to Amazon ECS
+name: Deploy 'prod' to Amazon EC2
 
 on:
   push:
@@ -19,7 +19,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION_CODE }}
 
       - name: Upload to AWS ECR
         id: login-ecr


### PR DESCRIPTION
### 개요

- 파이프라인이 prod에서 작동할 때, 에러가 발생한다.

### 수정 사항 및 원인 

- 파이프라인에서 아마존 REGION 정보가 필요한데, 현재 내부에서 에러가 발생한다. 조사한 결과, https://github.com/aws-actions/configure-aws-credentials/issues/402 에서처럼, 현재 사용 중인 변수명이 내부와 충돌한다. 따라서 이 변수명을 변경하자

- 추가로, 파이프라인 이름 수정