### PR TITLE
fix(ci): Secret 변수명 불일치 문제 해결

### DIFF
--- a/.github/workflows/deploys.yml
+++ b/.github/workflows/deploys.yml
@@ -18,7 +18,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: ${{ secrets.AWS_REGION_CODE }}
 
       - name: Upload to AWS ECR


### PR DESCRIPTION
### 개요

- AWS_SECRET_KEY의 이름으로 깃헙 시크릿과 동일하게 맞춰준다