### PR TITLE
fix(ci): docker 태그 명렁어 오타 수정

### DIFF
--- a/.github/workflows/deploys.yml
+++ b/.github/workflows/deploys.yml
@@ -31,7 +31,7 @@ jobs:
           ECR_REPOSITORY: dife-ecr
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest ./rest-api
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest ./rest-api
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 


### PR DESCRIPTION
### 개요

- docker 빌드 시에 멀티 태그를 달을 때는 -t가 하나 더 있어야하는데 빠졌다. 따라서 수정해주자