### PR TITLE
fix(ci): EC2에서 도커 이미지를 PULL하지 못하는 현상 해결

### DIFF
--- a/.github/workflows/deploys.yml
+++ b/.github/workflows/deploys.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build, tag, and push image to ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: dife-ecr
+          ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest ./rest-api
@@ -38,6 +38,9 @@ jobs:
 
       - name: Deploy to EC2 Instance
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}


### PR DESCRIPTION
### 개요

- 파이프 라인에서, 도커 이미지가 PULL되지 않는 문제가 생겼다. 확인 결과, 추가 env 변수 정보가 action step에서 받지 못하고 있었다
따라서 추가해준다