### PR TITLE
fix(ci): EC2 아마존 계정 설정 부재로 인한 docker image 부재

### DIFF
--- a/.github/workflows/deploys.yml
+++ b/.github/workflows/deploys.yml
@@ -47,6 +47,11 @@ jobs:
           key: ${{ secrets.EC2_SSH_PRIVATE_KEY }}
           port: ${{ secrets.EC2_SSH_PORT }}
           script: |
+            aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_KEY }} 
+            aws configure set default.region ${{ secrets.AWS_REGION_CODE }}
+            aws configure set default.ouput json
+            
             docker stop myapp || true
             docker rm myapp || true
             docker pull $ECR_REGISTRY/$ECR_REPOSITORY:latest


### PR DESCRIPTION
### 개요

- EC2 아마존 계정 설정을 해야지 docker image를 ecr에서 가져올 수 있다.
- 특히, 이후에 aws configure 이 부분 EC2 UserData.sh로 빼서 최초에만 실행하도록 변경예정 (TODO)