### PR TITLE
fix(ci): Github action 실행 전에 .aws 폴더를 삭제해서 새로 credential을 정할 수 있도록 한다

### DIFF
--- a/.github/workflows/deploys.yml
+++ b/.github/workflows/deploys.yml
@@ -58,6 +58,7 @@ jobs:
           port: ${{ secrets.EC2_SSH_PORT }}
           envs: ECR_REGISTRY, ECR_REPOSITORY, AWS_ACCESS_KEY_ID, AWS_SECRET_KEY, AWS_REGION_CODE, AWS_S3_BUCKET_NAME, DB_URL, DB_USER, DB_PASSWORD, JWT_SECRET, GOOGLE_EMAIL, GOOGLE_APP_PASSWORD
           script: |
+            sudo rm -rf .aws
             aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
             aws configure set aws_secret_access_key $AWS_SECRET_KEY
             aws configure set default.region $AWS_REGION_CODE


### PR DESCRIPTION
### 개요

.aws 폴더 삭제를 실행 시마다 삭제 안하면 새로운 credential set이 이루어지지 않음 따라서 수정한다.