### PR TITLE
fix(ci): ddl-auto: create를 임시로 활성화 하여 에러를 확인 및 해결

### DIFF
--- a/rest-api/src/main/resources/application.yml
+++ b/rest-api/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
         database-platform: org.hibernate.dialect.MySQLDialect
         open-in-view: false
         show-sql: true
+        hibernate:
+            ddl-auto: create
 
     datasource:
         driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
현재 hibernate 관련 에러가 뜨는 데, Table 생성이 되지 않아 그런 것으로
추측한다. 따라서, 이 에러를 해결해보기 위해 Table Creation을 자동으로
임시 전환한다.