### PR TITLE
feat(connect): DELETE: /api/connects/{id} 구현

### DIFF
--- a/rest-api/src/main/java/com/dife/api/controller/ConnectController.java
+++ b/rest-api/src/main/java/com/dife/api/controller/ConnectController.java
@@ -33,4 +33,10 @@ public class ConnectController {
         connectService.acceptConnect(requestDto, auth.getName());
         return new ResponseEntity<>(OK);
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteConnect(@PathVariable("id") Long id, Authentication auth) {
+        connectService.deleteConnect(id, auth.getName());
+        return new ResponseEntity<>(OK);
+    }
 }

--- a/rest-api/src/main/java/com/dife/api/service/ConnectService.java
+++ b/rest-api/src/main/java/com/dife/api/service/ConnectService.java
@@ -54,6 +54,13 @@ public class ConnectService {
         connect.setStatus(ConnectStatus.ACCEPTED);
     }
 
+    public void deleteConnect(Long id, String email) {
+        if (!isConnectRelevant(id, email)) {
+            throw new ConnectUnauthorizedException();
+        }
+        connectRepository.deleteById(id);
+    }
+
     public boolean isConnectRelevant(Long id, String email) {
         Connect connect = connectRepository.findById(id).orElseThrow(ConnectNotFoundException::new);
         String fromMemberEmail = connect.getFromMember().getEmail();


### PR DESCRIPTION
### 개요

- 보냈던 Connect 요청을 본인이 취소하거나, 상대방의 Connect 요청을
거절하고 싶을 때 요청하는 메서드이다.

### 수정 사항

- DELETE는 REST API 규격을 확인해보니, 해당 리소스가 없어도 200을
리턴하여 멱등성을 유지함

- 추가로, DELETE는 PATCH와 마찬가지로, 삭제된 리소스를 리턴하지 않고
코드만 리턴하는 경우가 더 흔함

- connecerService에서는 해당 커넥트와 연관된 멤버 (보낸 사람 또는 받은
사람인지 확인하는 Util 함수인 `isConnectRelevant`로 체크