### PR TITLE
feat(connect): GET: /api/connects/ 구현

### DIFF
--- a/rest-api/src/main/java/com/dife/api/controller/ConnectController.java
+++ b/rest-api/src/main/java/com/dife/api/controller/ConnectController.java
@@ -11,6 +11,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -20,7 +23,12 @@ import static org.springframework.http.HttpStatus.OK;
 public class ConnectController {
 
     private final ConnectService connectService;
-    private final MemberService memberService;
+
+    @GetMapping("/")
+    public ResponseEntity<List<ConnectResponseDto>> getConnects(Authentication auth) {
+        List<ConnectResponseDto> responseDto = connectService.getConnects(auth.getName());
+        return ResponseEntity.status(OK).body(responseDto);
+    }
 
     @PostMapping("/")
     public ResponseEntity<ConnectResponseDto> createConnect(@Valid @RequestBody ConnectRequestDto requestDto, Authentication auth) {

--- a/rest-api/src/main/java/com/dife/api/repository/ConnectRepository.java
+++ b/rest-api/src/main/java/com/dife/api/repository/ConnectRepository.java
@@ -1,14 +1,21 @@
 package com.dife.api.repository;
 
 import com.dife.api.model.Connect;
+import com.dife.api.model.ConnectStatus;
 import com.dife.api.model.Member;
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface ConnectRepository extends JpaRepository<Connect, Long> {
+    @Query("SELECT c FROM Connect c WHERE (c.toMember = :member OR c.fromMember = :member) AND c.status = :status")
+    List<Connect> findAllByMemberAndStatus(@Param("member") Member member, @Param("status") ConnectStatus status);
+
     @Query("SELECT c FROM Connect c WHERE (c.toMember = :member1 AND c.fromMember = :member2) OR (c.fromMember = :member1 AND c.toMember = :member2) ")
     Optional<Connect> findByMemberPair(@Param("member1") Member member1, @Param("member2") Member member2);
 

--- a/rest-api/src/main/java/com/dife/api/service/ConnectService.java
+++ b/rest-api/src/main/java/com/dife/api/service/ConnectService.java
@@ -9,10 +9,15 @@ import com.dife.api.model.dto.ConnectRequestDto;
 import com.dife.api.model.dto.ConnectResponseDto;
 import com.dife.api.repository.ConnectRepository;
 import com.dife.api.repository.MemberRepository;
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +27,14 @@ public class ConnectService {
     private final MemberRepository memberRepository;
 
     private final ModelMapper modelMapper;
+
+    @Transactional(readOnly = true)
+    public List<ConnectResponseDto> getConnects(String currentMemberEmail) {
+        Member currentMember = memberRepository.findByEmail(currentMemberEmail).orElseThrow(MemberNotFoundException::new);
+        List<Connect> connects = connectRepository.findAllByMemberAndStatus(currentMember, ConnectStatus.ACCEPTED);
+
+        return connects.stream().map(c -> modelMapper.map(c, ConnectResponseDto.class)).collect(toList());
+    }
 
     public ConnectResponseDto saveConnect(ConnectRequestDto dto, String currentMemberEmail) {
         Member currentMember = memberRepository.findByEmail(currentMemberEmail).orElseThrow(MemberNotFoundException::new);


### PR DESCRIPTION
### 개요

- 커넥트 목록을 가져오는 엔드포인트를 구현한다.
- 특히나, 커넥트 목록을 가져온다는 것은, 친구의 목록을 가져오는 것이다. 이를 염두해두고 구현한다.

### 수정 사항

- Controller
  - 현재 유저 `auth`만 가지고 전체 목록 가져올 수 있도록 service로 패스
- Service
  - 현재 멤버를 가져오고, `Connect status`가 `ACCEPTED`인 목록만 가져온다. (이후에 다른 status도 필요하다하면 확장 예정)
  - 여러 커넥트가 있을 수 있으니 `List`로 받아온다.
  - `@Transactional`을 spring 내부에 구현된 annotation으로 `import` 문을 변경
  - `readOnly true`를 걸어서 `getConnects`에서 데이터가 변경되지 않도록 방지