### PR TITLE
feat(connect): GET: /api/connects?member_id={id} 구현

### DIFF
--- a/rest-api/src/main/java/com/dife/api/controller/ConnectController.java
+++ b/rest-api/src/main/java/com/dife/api/controller/ConnectController.java
@@ -30,6 +30,12 @@ public class ConnectController {
         return ResponseEntity.status(OK).body(responseDto);
     }
 
+    @GetMapping(value = "/", params = "member_id")
+    public ResponseEntity<ConnectResponseDto> getConnect(@RequestParam("member_id") Long memberId, Authentication auth) {
+        ConnectResponseDto responseDto = connectService.getConnect(memberId, auth.getName());
+        return ResponseEntity.status(OK).body(responseDto);
+    }
+
     @PostMapping("/")
     public ResponseEntity<ConnectResponseDto> createConnect(@Valid @RequestBody ConnectRequestDto requestDto, Authentication auth) {
         ConnectResponseDto responseDto = connectService.saveConnect(requestDto, auth.getName());

--- a/rest-api/src/main/java/com/dife/api/service/ConnectService.java
+++ b/rest-api/src/main/java/com/dife/api/service/ConnectService.java
@@ -36,6 +36,16 @@ public class ConnectService {
         return connects.stream().map(c -> modelMapper.map(c, ConnectResponseDto.class)).collect(toList());
     }
 
+    @Transactional(readOnly = true)
+    public ConnectResponseDto getConnect(Long memberId, String currentMemberEmail) {
+        Member currentMember = memberRepository.findByEmail(currentMemberEmail).orElseThrow(MemberNotFoundException::new);
+        Member otherMember = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+        Connect connect = connectRepository.findByMemberPair(otherMember, currentMember).orElseThrow(ConnectNotFoundException::new);
+
+        return modelMapper.map(connect, ConnectResponseDto.class);
+    }
+
     public ConnectResponseDto saveConnect(ConnectRequestDto dto, String currentMemberEmail) {
         Member currentMember = memberRepository.findByEmail(currentMemberEmail).orElseThrow(MemberNotFoundException::new);
         Member toMember = memberRepository.findById(dto.getToMemberId()).orElseThrow(MemberNotFoundException::new);


### PR DESCRIPTION
### 개요

- GET으로 멤버 id를 백엔드로 요청해서 해당 멤버와 나와의 커넥트를 가져오는 엔드포인트를 구현하자
- 프론트에서 활용 방안은, 내가 해당 멤버와 커넥트 되어있는지에 대한 확인으로 사용한다.

### 수정 사항

- query param으로 member_id를 받아와서 조회한다. 특히나, Transaction read=true를 걸어서 이후의 코드 실수로 잘못된 데이터가 쓰이는 것을
방지한다.