### PR TITLE
Feat/swagger signup : Swagger 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
 
 	implementation(platform("software.amazon.awssdk:bom:2.21.1"))
 	implementation("software.amazon.awssdk:s3")
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dife/api/ExceptionResonse.java
+++ b/src/main/java/com/dife/api/ExceptionResonse.java
@@ -8,5 +8,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public class ExceptionResonse {
 
-    private final String exceptionMessage;
+    private final Boolean success;
+    private final String message;
 }

--- a/src/main/java/com/dife/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/dife/api/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     {
         return ResponseEntity
                 .status(INTERNAL_SERVER_ERROR.value())
-                .body(new ExceptionResonse(exception.getMessage()));
+                .body(new ExceptionResonse(false, exception.getMessage()));
     }
 
     @ExceptionHandler(DuplicateException.class)
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     {
         return ResponseEntity
                 .status(CONFLICT.value())
-                .body(new ExceptionResonse(exception.getMessage()));
+                .body(new ExceptionResonse(false, exception.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
@@ -34,7 +34,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     {
         return ResponseEntity
                 .status(INTERNAL_SERVER_ERROR.value())
-                .body(new ExceptionResonse(exception.getMessage()));
+                .body(new ExceptionResonse(false, exception.getMessage()));
     }
 
     @ExceptionHandler(RegisterException.class)
@@ -42,20 +42,20 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     {
         return ResponseEntity
                 .status(UNPROCESSABLE_ENTITY.value())
-                .body(new ExceptionResonse(exception.getMessage()));
+                .body(new ExceptionResonse(false, exception.getMessage()));
     }
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ExceptionResonse> handleIllegalArgumentException(IllegalArgumentException exception)
     {
         return ResponseEntity
                 .status(UNAUTHORIZED.value())
-                .body(new ExceptionResonse(exception.getMessage()));
+                .body(new ExceptionResonse(false, exception.getMessage()));
     }
     @ExceptionHandler(ConnectDuplicateException.class)
     public ResponseEntity<ExceptionResonse> handleConnectException(ConnectDuplicateException exception) {
         return ResponseEntity
                 .status(CONFLICT)
-                .body(new ExceptionResonse(exception.getMessage()));
+                .body(new ExceptionResonse(false, exception.getMessage()));
     }
 
     @ExceptionHandler(PostNotFoundException.class)
@@ -63,27 +63,27 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     {
         return ResponseEntity
                 .status(UNAUTHORIZED.value())
-                .body(new ExceptionResonse(exception.getMessage()));
+                .body(new ExceptionResonse(false, exception.getMessage()));
     }
 
     @ExceptionHandler(ConnectNotFoundException.class)
     public ResponseEntity<ExceptionResonse> handleConnectException(ConnectNotFoundException exception) {
         return ResponseEntity
                 .status(NOT_FOUND)
-                .body(new ExceptionResonse(exception.getMessage()));
+                .body(new ExceptionResonse(false, exception.getMessage()));
     }
     
     @ExceptionHandler(ConnectUnauthorizedException.class)
     public ResponseEntity<ExceptionResonse> handleConnectException(ConnectUnauthorizedException exception) {
         return ResponseEntity
                 .status(UNAUTHORIZED)
-                .body(new ExceptionResonse(exception.getMessage()));
+                .body(new ExceptionResonse(false, exception.getMessage()));
     }
 
     @ExceptionHandler(IdenticalConnectException.class)
     public ResponseEntity<ExceptionResonse> handleConnectException(IdenticalConnectException exception) {
         return ResponseEntity
                 .status(BAD_REQUEST)
-                .body(new ExceptionResonse(exception.getMessage()));
+                .body(new ExceptionResonse(false, exception.getMessage()));
     }
 }

--- a/src/main/java/com/dife/api/config/SecurityConfig.java
+++ b/src/main/java/com/dife/api/config/SecurityConfig.java
@@ -49,6 +49,8 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(requests -> {
                     requests.requestMatchers(
+                            "/swagger-ui/**",
+                            "/api/v1/api-docs",
                             "/api/members/register",
                             "/api/members/change-password",
                             "/api/members/login").permitAll();

--- a/src/main/java/com/dife/api/config/SecurityConfig.java
+++ b/src/main/java/com/dife/api/config/SecurityConfig.java
@@ -48,10 +48,16 @@ public class SecurityConfig {
                                 sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(requests -> {
+<<<<<<< HEAD:src/main/java/com/dife/api/config/SecurityConfig.java
                     requests.requestMatchers(
                             "/api/members/register",
                             "/api/members/change-password",
                             "/api/members/login").permitAll();
+=======
+                    requests.requestMatchers("/api/members/register/**", "/api/members/change-password", "/api/members/login").permitAll();
+                    requests.requestMatchers(request -> request.getParameter("username") != null).permitAll();
+                    requests.requestMatchers("/api/members/**").authenticated();
+>>>>>>> c3cb7f4 (fix/member-signup-2: 회원가입 수정사항 반영):rest-api/src/main/java/com/dife/api/config/SecurityConfig.java
                     requests.requestMatchers("/api/**").authenticated();
                 })
                 .build();

--- a/src/main/java/com/dife/api/config/SecurityConfig.java
+++ b/src/main/java/com/dife/api/config/SecurityConfig.java
@@ -48,16 +48,10 @@ public class SecurityConfig {
                                 sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(requests -> {
-<<<<<<< HEAD:src/main/java/com/dife/api/config/SecurityConfig.java
                     requests.requestMatchers(
                             "/api/members/register",
                             "/api/members/change-password",
                             "/api/members/login").permitAll();
-=======
-                    requests.requestMatchers("/api/members/register/**", "/api/members/change-password", "/api/members/login").permitAll();
-                    requests.requestMatchers(request -> request.getParameter("username") != null).permitAll();
-                    requests.requestMatchers("/api/members/**").authenticated();
->>>>>>> c3cb7f4 (fix/member-signup-2: 회원가입 수정사항 반영):rest-api/src/main/java/com/dife/api/config/SecurityConfig.java
                     requests.requestMatchers("/api/**").authenticated();
                 })
                 .build();

--- a/src/main/java/com/dife/api/config/SwaggerConfig.java
+++ b/src/main/java/com/dife/api/config/SwaggerConfig.java
@@ -37,7 +37,7 @@ public class SwaggerConfig {
                 .type(SecurityScheme.Type.HTTP)
                 .in(SecurityScheme.In.HEADER)
                 .name("Authorization")
-                .scheme("bearer");
+                .scheme("Bearer");
 
         SecurityRequirement securityRequirement = new SecurityRequirement()
                 .addList("Bearer Token");

--- a/src/main/java/com/dife/api/config/SwaggerConfig.java
+++ b/src/main/java/com/dife/api/config/SwaggerConfig.java
@@ -1,0 +1,72 @@
+package com.dife.api.config;
+
+import com.dife.api.model.dto.LoginSuccessDto;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.*;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.QueryParameter;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Dife API",
+                description = "회원 명세서 작성중",
+                version = "v1"
+        )
+)
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI()
+    {
+        SecurityScheme apiKey = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization")
+                .scheme("bearer");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Bearer Token");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+                .addSecurityItem(securityRequirement);
+    }
+    @Bean
+    public OpenApiCustomizer customerGlobalHeaderOpenApiCustomizer() {
+        return openApi -> {
+            openApi.path("/api/members/login", new PathItem()
+                    .post(new Operation()
+                            .summary("로그인 API")
+                            .operationId("loginUser")
+                            .tags(Arrays.asList("Member API"))
+                            .parameters(Arrays.asList(
+                                    new QueryParameter().name("email").required(true).schema(new Schema<String>().type("string").example("user@example.com")),
+                                    new QueryParameter().name("password").required(true).schema(new Schema<String>().type("string"))
+                            ))
+                            .responses(new ApiResponses()
+                                    .addApiResponse("200", new ApiResponse()
+                                            .description("로그인 성공 예시")
+                                            .content(new Content().addMediaType("application/json",
+                                                    new MediaType().schema(new Schema<String>().example(new LoginSuccessDto("Given Bearer Token")))))
+                                    )
+                            )
+                    )
+            );
+        };
+    }
+}

--- a/src/main/java/com/dife/api/controller/MemberController.java
+++ b/src/main/java/com/dife/api/controller/MemberController.java
@@ -4,17 +4,21 @@ package com.dife.api.controller;
 import com.dife.api.model.MbtiCategory;
 import com.dife.api.model.Member;
 import com.dife.api.model.dto.*;
-import com.dife.api.service.FileService;
 import com.dife.api.service.MemberService;
-import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -22,8 +26,8 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.HashMap;
 import java.util.Set;
 
-import static org.springframework.http.HttpStatus.CREATED;
 
+@Tag(name = "Member API", description = "Member API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
@@ -31,15 +35,17 @@ import static org.springframework.http.HttpStatus.CREATED;
 public class MemberController {
 
     private final MemberService memberService;
-    private final FileService fileService;
 
     @PostMapping("/register")
-    public ResponseEntity<MemberResponseDto> registerEmailAndPassword(@Valid @RequestBody RegisterEmailAndPasswordRequestDto dto) {
+    @Operation(summary = "회원가입1 API", description = "이메일과 비밀번호를 사용하여 새 회원을 등록합니다.")
+    @ApiResponse(responseCode = "201", description = "회원가입1 성공 예시", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = RegisterResponseDto.class))})
+    public ResponseEntity<RegisterResponseDto> registerEmailAndPassword(
+            @RequestBody(description = "이메일과 비밀번호를 포함하는 등록 데이터", required = true, content = @Content(schema = @Schema(implementation = RegisterEmailAndPasswordRequestDto.class))) RegisterEmailAndPasswordRequestDto dto) {
         Member member = memberService.registerEmailAndPassword(dto);
 
         return ResponseEntity
-                .status(CREATED.value())
-                .body(new MemberResponseDto(member));
+                .status(HttpStatus.CREATED)
+                .body(new RegisterResponseDto(member));
     }
     @RequestMapping(path = "/{id}", method = RequestMethod.HEAD)
     public ResponseEntity<Void> checkUsername(@RequestParam("username") String username, @PathVariable Long id) {
@@ -53,6 +59,8 @@ public class MemberController {
     }
 
     @PutMapping( "/{id}")
+    @Operation(summary = "회원가입2 API", description = "회원가입 세부사항을 입력합니다.")
+    @ApiResponse(responseCode = "201", description = "회원가입2 성공 예시", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MemberResponseDto.class))})
     public ResponseEntity<MemberResponseDto> registerDetail(@RequestParam("username") String username,
                                                            @RequestParam("is_korean") Boolean is_korean,
                                                            @RequestParam("bio") String bio,

--- a/src/main/java/com/dife/api/controller/MemberController.java
+++ b/src/main/java/com/dife/api/controller/MemberController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.ResponseEntity;
@@ -48,6 +47,7 @@ public class MemberController {
                 .body(new RegisterResponseDto(member));
     }
     @RequestMapping(path = "/{id}", method = RequestMethod.HEAD)
+    @Operation(summary = "중복 닉네임 확인", description = "중복 닉네임 여부를 확인합니다.")
     public ResponseEntity<Void> checkUsername(@RequestParam("username") String username, @PathVariable Long id) {
         Boolean isValid = memberService.checkUsername(username);
 
@@ -58,16 +58,16 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.CONFLICT).build();
     }
 
-    @PutMapping( "/{id}")
+    @PutMapping( value = "/{id}", consumes = "multipart/form-data")
     @Operation(summary = "회원가입2 API", description = "회원가입 세부사항을 입력합니다.")
     @ApiResponse(responseCode = "201", description = "회원가입2 성공 예시", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MemberResponseDto.class))})
     public ResponseEntity<MemberResponseDto> registerDetail(@RequestParam("username") String username,
                                                            @RequestParam("is_korean") Boolean is_korean,
-                                                           @RequestParam("bio") String bio,
-                                                           @RequestParam("mbti") MbtiCategory mbti,
-                                                           @RequestParam("hobbies") Set<String> hobbies,
+                                                           @RequestParam(value="bio", required = false) String bio,
+                                                           @RequestParam(value="mbti", required = false) MbtiCategory mbti,
+                                                           @RequestParam(value="hobbies", required = false) Set<String> hobbies,
                                                            @RequestParam("languages") Set<String> languages,
-                                                           @RequestParam("profile_img") MultipartFile profile_img,
+                                                           @RequestParam(value="profile_img", required = false) MultipartFile profile_img,
                                                            @RequestParam("verification_file") MultipartFile verification_file,
                                                            @PathVariable Long id) {
 
@@ -76,6 +76,8 @@ public class MemberController {
     }
 
     @GetMapping("/profile")
+    @Operation(summary = "마이페이지 API", description = "로그인 한 유저의 개인 정보를 확인할 수 있는 마이페이지입니다.")
+    @ApiResponse(responseCode = "200", description = "마이페이지 정보 예시", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = MemberResponseDto.class))})
     public ResponseEntity<MemberResponseDto> profile(Authentication auth)
     {
         Member currentMember = memberService.getMember(auth.getName());
@@ -85,6 +87,8 @@ public class MemberController {
     }
 
     @PutMapping("/change-password")
+    @Operation(summary = "비밀번호 변경 API", description = "이메일을 발송해 유저는 변경된 비밀번호를 받아 유효한 로그인을 진행할 수 있게 됩니다.")
+    @ApiResponse(responseCode = "200", description = "비밀번호 변경 발송 예시", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = VerifyEmailDto.class))})
     public ResponseEntity<HashMap> mailCheck(@RequestBody VerifyEmailDto emailDto)
     {
         boolean success = memberService.changePassword(emailDto);

--- a/src/main/java/com/dife/api/jwt/JWTFilter.java
+++ b/src/main/java/com/dife/api/jwt/JWTFilter.java
@@ -40,7 +40,9 @@ public class JWTFilter  extends OncePerRequestFilter {
 
         if (servletPath.startsWith("/api/members/register")
                 || servletPath.equals("/api/members/change-password")
-                || servletPath.equals("/api/members/login"))
+                || servletPath.equals("/api/members/login")
+                || servletPath.startsWith("/swagger-ui")
+                || servletPath.equals("/api/v1/api-docs"))
         {
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/com/dife/api/jwt/LoginFilter.java
+++ b/src/main/java/com/dife/api/jwt/LoginFilter.java
@@ -48,7 +48,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             String errorMessage = "이메일과 비밀번호는 필수 사항";
             log.warn("이메일과 비밀번호는 필수 사항");
 
-            ExceptionResonse exceptionResponse = new ExceptionResonse(errorMessage);
+            ExceptionResonse exceptionResponse = new ExceptionResonse(false, errorMessage);
 
             ObjectMapper objectMapper = new ObjectMapper();
             String result = null;
@@ -101,7 +101,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         log.error("로그인 실패");
         String errorMessage = "인증에 실패했습니다: " + failed.getMessage();
 
-        ExceptionResonse exceptionResponse = new ExceptionResonse(errorMessage);
+        ExceptionResonse exceptionResponse = new ExceptionResonse(false, errorMessage);
 
         ObjectMapper objectMapper = new ObjectMapper();
         String result = objectMapper.writeValueAsString(exceptionResponse);

--- a/src/main/java/com/dife/api/model/dto/MemberResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/MemberResponseDto.java
@@ -5,6 +5,7 @@ import com.dife.api.model.Language;
 import com.dife.api.model.MbtiCategory;
 import com.dife.api.model.Member;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -15,38 +16,55 @@ import java.util.stream.Collectors;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Schema(description = "회원 응답 데이터 전송 객체")
 public class MemberResponseDto {
 
+    @Schema(description = "이메일 주소", example = "gusuyeon@gmail.com")
     private String email;
 
+    @Schema(description = "실명")
     private String name;
 
+    @Schema(description = "학번")
     private String student_id;
 
+    @Schema(description = "전공")
     private String major;
 
+    @Schema(description = "역할")
     private String role;
 
+    @Schema(description = "닉네임", example = "sooya")
     private String username;
 
+    @Schema(description = "내국인 여부", example = "true")
     private Boolean is_korean;
 
+    @Schema(description = "프로필 공개 여부", example = "true")
     private Boolean is_public;
 
+    @Schema(description = "MBTI", example = "ENTJ")
     private MbtiCategory mbti;
 
+    @Schema(description = "언어",  example = "Korean, English")
     private Set<String> languages;
 
+    @Schema(description = "취미",  example = "Soccer")
     private Set<String> hobbies;
 
+    @Schema(description = "프로필 파일 이름", example = "cookie.jpeg")
     private String profile_file_id;
 
+    @Schema(description = "한줄 소개", example = "hello")
     private String bio;
 
+    @Schema(description = "재학생 인증 여부", example = "false")
     private Boolean is_verified;
 
+    @Schema(description = "프로필 생성 일시")
     private LocalDateTime created;
 
+    @Schema(description = "프로필 수정 일시")
     private LocalDateTime modified;
 
     public MemberResponseDto(Member member) {

--- a/src/main/java/com/dife/api/model/dto/RegisterEmailAndPasswordRequestDto.java
+++ b/src/main/java/com/dife/api/model/dto/RegisterEmailAndPasswordRequestDto.java
@@ -1,7 +1,9 @@
 package com.dife.api.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,13 +13,18 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Schema(description = "회원가입 데이터 전송 객체")
 public class RegisterEmailAndPasswordRequestDto {
 
-    @NotNull()
-    @Email
+    @NotNull(message = "이메일을 입력해주세요!")
+    @Email(message = "이메일 형식에 맞지 않습니다!")
+    @Schema(description = "사용자 이메일", example = "example@gmail.com")
     private String email;
 
-    @NotNull()
+    @NotNull(message = "비밀번호를 입력해주세요!")
+    @Schema(description = "비밀번호", example = "password")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}",
+            message = "비밀번호는 영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상 포함된 8자 ~ 20자의 비밀번호여야 합니다.")
     private String password;
 
 }

--- a/src/main/java/com/dife/api/model/dto/RegisterResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/RegisterResponseDto.java
@@ -1,0 +1,38 @@
+package com.dife.api.model.dto;
+
+import com.dife.api.model.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "회원가입 응답 객체")
+public class RegisterResponseDto {
+
+    @Schema(description = "회원가입 성공여부", example = "true")
+    private Boolean success;
+
+    @Schema(description = "응답 메시지", example = "회원가입 성공")
+    private String message;
+
+    @Schema(description = "회원가입된 유저의 이메일", example = "example@gmail.com")
+    private String email;
+
+    @Schema(description = "생성된 유저 고유 번호", example = "1")
+    private Long member_id;
+
+
+    public RegisterResponseDto(Member member)
+    {
+        this.success = true;
+        this.message = "회원가입 성공";
+        this.email = member.getEmail();
+        this.member_id = member.getId();
+    }
+
+}

--- a/src/main/java/com/dife/api/model/dto/VerifyEmailDto.java
+++ b/src/main/java/com/dife/api/model/dto/VerifyEmailDto.java
@@ -1,5 +1,8 @@
 package com.dife.api.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,5 +14,8 @@ import lombok.Setter;
 @NoArgsConstructor
 public class VerifyEmailDto {
 
+    @NotNull(message = "이메일을 입력해주세요!")
+    @Email(message = "이메일 형식에 맞지 않습니다!")
+    @Schema(description = "사용자 이메일", example = "example@gmail.com")
     private String email;
 }

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -43,8 +43,8 @@ public class MemberService {
             throw new RegisterException("유효하지 않은 이메일입니다");
         }
 
-        if (dto.getPassword() == null || dto.getPassword().length() < 8 || !dto.getPassword().matches("^[a-zA-Z0-9]{8,}$")) {
-            throw new RegisterException("영문, 숫자 포함 8자 이상의 비밀번호를 입력해주세요");
+        if (dto.getPassword() == null || dto.getPassword().length() < 8 || !dto.getPassword().matches("(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}")) {
+            throw new RegisterException("비밀번호는 영문 대,소문자와 숫자, 특수기호가 적어도 1개 이상 포함된 8자 ~ 20자의 비밀번호여야 합니다.");
         }
 
         if (memberRepository.existsByEmail(dto.getEmail()))
@@ -76,15 +76,25 @@ public class MemberService {
     {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new MemberException("회원을 찾을 수 없습니다!"));
-        FileDto profileImgPath = fileService.upload(profile_img);
-        FileDto verificationImgPath = fileService.upload(verification_file);
+
+        if (profile_img != null && !profile_img.isEmpty()) {
+            FileDto profileImgPath = fileService.upload(profile_img);
+            member.setProfile_file_id(profileImgPath.getName());
+        } else {
+            member.setProfile_file_id(null);
+        }
+
+        if (verification_file != null && !verification_file.isEmpty()) {
+            FileDto verificationImgPath = fileService.upload(verification_file);
+            member.setVerification_file_id(verificationImgPath.getName());
+        } else {
+            member.setVerification_file_id(null);
+        }
 
         member.setUsername(username);
         member.setIs_korean(is_korean);
         member.setBio(bio);
         member.setMbti(mbti);
-        member.setProfile_file_id(profileImgPath.getName());
-        member.setVerification_file_id(verificationImgPath.getName());
 
         Set<Hobby> myhobbies = new HashSet<>();
 

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -76,7 +76,6 @@ public class MemberService {
     {
         Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new MemberException("회원을 찾을 수 없습니다!"));
-
         FileDto profileImgPath = fileService.upload(profile_img);
         FileDto verificationImgPath = fileService.upload(verification_file);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,21 @@ spring:
 
 jwt:
     secret: ${JWT_SECRET}
+springdoc:
+    swagger-ui:
+        groups-order: DESC
+        tags-sorter: alpha
+        operations-sorter: method
+        disable-swagger-default-url: true
+        display-request-duration: true
+        default-models-expand-depth: -1
+        default-model-expand-depth: -1
+    api-docs:
+      path: /api/v1/api-docs
+    show-actuator: true
+    default-consumes-media-type: application/x-www-form-urlencoded
+    default-produces-media-type: application/json
+    writer-with-default-pretty-printer: true
+    model-and-view-allowed: true
+    paths-to-match:
+        - /api/**


### PR DESCRIPTION
### 개요
- #93 에서 추가된 branch
- 프론트와의 협업을 위한 자동화 API 명세서 역할을 하는 **Swagge**r 초기 세팅
- 세부사항은 커밋 확인
- 참고사항 : swagger에서는 기본 response code로 200이 자동으로 지정되어 있어서 이를 예시 코드로 막아서 세팅해둘 예정


---

### 테스트 방법

1. swagger ui 접근 
접근 주소: htttp://localhost:8080/swagger-ui/index.html
+ 서버 시작 (difeApplication)
<img width="837" alt="스크린샷 2024-04-26 오후 2 50 16" src="https://github.com/team-diverse/dife-backend/assets/124496650/8e9aaeb7-59d2-4bbd-aa9a-bf999f45e54c">


2. 명세서 api-docs 접근
<img width="864" alt="스크린샷 2024-04-26 오후 10 35 10" src="https://github.com/team-diverse/dife-backend/assets/124496650/cb767a81-df02-47ad-a9e2-9a2f4a9273a6">

3. API Test
- Try it out -> 입력값 Test 가능
- form에 맞는 입력값 적고 Execute
<img width="792" alt="스크린샷 2024-04-26 오후 3 27 33" src="https://github.com/team-diverse/dife-backend/assets/124496650/2ec8f602-5308-4d61-afcd-e34e53867f22">

결과
<img width="807" alt="스크린샷 2024-04-26 오후 3 28 06" src="https://github.com/team-diverse/dife-backend/assets/124496650/f9fdeae3-46c8-42d0-adb3-2ad85cd040a5">

- 로그인 Test 도 동일

JWT Token Authorized 성공시
<img width="571" alt="스크린샷 2024-04-26 오후 10 16 23" src="https://github.com/team-diverse/dife-backend/assets/124496650/ba999017-b6db-4551-80d2-9abb101aa358">



추후 진행 사항
- Swagger가 Token을 감지 못하는 오류 (회원가입2 API) issue
- S3 token 만료 issue

해결하기!