### PR TITLE
Feat/chat group http

### DIFF
--- a/src/main/java/com/dife/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/dife/api/GlobalExceptionHandler.java
@@ -78,4 +78,27 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 		return ResponseEntity.status(BAD_REQUEST)
 				.body(new ExceptionResonse(false, exception.getMessage()));
 	}
+
+	@ExceptionHandler(ChatRoomCountException.class)
+	public ResponseEntity<ExceptionResonse> handleChatRoomCountException(
+			ChatRoomCountException exception) {
+		return ResponseEntity.status(BAD_REQUEST)
+				.body(new ExceptionResonse(false, exception.getMessage()));
+	}
+
+	@ExceptionHandler(ChatRoomDuplicateException.class)
+	public ResponseEntity<ExceptionResonse> handleChatRoomDuplicateException(
+			ChatRoomDuplicateException exception) {
+		return ResponseEntity.status(CONFLICT)
+				.body(new ExceptionResonse(false, exception.getMessage()));
+	}
+
+	@ExceptionHandler(ChatRoomException.class)
+	public ResponseEntity<ExceptionResonse> handleChatRoomException(
+			ChatRoomException exception) {
+		return ResponseEntity.status(BAD_REQUEST)
+				.body(new ExceptionResonse(false, exception.getMessage()));
+	}
+
+
 }

--- a/src/main/java/com/dife/api/config/SecurityConfig.java
+++ b/src/main/java/com/dife/api/config/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig {
 									.requestMatchers(
 											"/swagger-ui/**",
 											"/api/v1/api-docs",
+											"/api/chat/**",
 											"/api/members/register",
 											"/api/members/change-password",
 											"/api/members/login")

--- a/src/main/java/com/dife/api/controller/ChatController.java
+++ b/src/main/java/com/dife/api/controller/ChatController.java
@@ -1,0 +1,37 @@
+package com.dife.api.controller;
+
+import com.dife.api.model.ChatRoom;
+import com.dife.api.model.dto.GroupChatRoomDto;
+import com.dife.api.service.ChatRoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+@Slf4j
+@Tag(name="Chat API", description = "Chat API")
+public class ChatController {
+
+    private final ChatRoomService chatRoomService;
+
+    @Operation(summary = "그룹 채팅방 생성", description = "사용자가 그룹 채팅방 생성")
+    @PostMapping
+    public ResponseEntity<GroupChatRoomDto> createGroupChatRoom(@RequestParam (value = "chatRoomName") String chatRoomName,
+                                                                @RequestParam (value = "chatRoomBio") String chatRoomBio,
+                                                                @RequestParam (value = "max_count") String max_count,
+                                                                @RequestParam (value = "min_count") String min_count) {
+
+        ChatRoom chatRoom = chatRoomService.createGroupChatRoom(chatRoomName, chatRoomBio, max_count, min_count);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(new GroupChatRoomDto(chatRoom));
+    }
+
+
+}

--- a/src/main/java/com/dife/api/exception/ChatRoomCountException.java
+++ b/src/main/java/com/dife/api/exception/ChatRoomCountException.java
@@ -1,0 +1,6 @@
+package com.dife.api.exception;
+
+public class ChatRoomCountException extends IllegalArgumentException{
+
+    public ChatRoomCountException() { super("그룹 채팅방의 최소 인원은 3명, 최대 인원은 30명입니다."); }
+}

--- a/src/main/java/com/dife/api/exception/ChatRoomDuplicateException.java
+++ b/src/main/java/com/dife/api/exception/ChatRoomDuplicateException.java
@@ -1,0 +1,7 @@
+package com.dife.api.exception;
+
+public class ChatRoomDuplicateException extends RuntimeException {
+	public ChatRoomDuplicateException() {
+		super("이미 해당 채팅방이름을 가진 채팅방이 존재합니다.");
+	}
+}

--- a/src/main/java/com/dife/api/exception/ChatRoomException.java
+++ b/src/main/java/com/dife/api/exception/ChatRoomException.java
@@ -1,0 +1,6 @@
+package com.dife.api.exception;
+
+public class ChatRoomException extends IllegalArgumentException{
+
+    public ChatRoomException(String message) { super(message); }
+}

--- a/src/main/java/com/dife/api/jwt/JWTFilter.java
+++ b/src/main/java/com/dife/api/jwt/JWTFilter.java
@@ -42,6 +42,7 @@ public class JWTFilter extends OncePerRequestFilter {
 				|| servletPath.equals("/api/members/change-password")
 				|| servletPath.equals("/api/members/login")
 				|| servletPath.startsWith("/swagger-ui")
+				|| servletPath.startsWith("/api/chat")
 				|| servletPath.equals("/api/v1/api-docs")) {
 			filterChain.doFilter(request, response);
 			return;

--- a/src/main/java/com/dife/api/model/ChatRoom.java
+++ b/src/main/java/com/dife/api/model/ChatRoom.java
@@ -1,0 +1,27 @@
+package com.dife.api.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "chatRoom")
+public class ChatRoom extends BaseTimeEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String chatRoomName;
+
+    private ChatRoomType chatRoomType;
+
+    @Embedded
+    private ChatRoomSetting chatRoomSetting;
+}

--- a/src/main/java/com/dife/api/model/ChatRoomSetting.java
+++ b/src/main/java/com/dife/api/model/ChatRoomSetting.java
@@ -1,0 +1,16 @@
+package com.dife.api.model;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Embeddable
+public class ChatRoomSetting {
+
+    private String chatRoomBio;
+    private Integer min_count;
+    private Integer max_count;
+
+}

--- a/src/main/java/com/dife/api/model/ChatRoomType.java
+++ b/src/main/java/com/dife/api/model/ChatRoomType.java
@@ -1,0 +1,6 @@
+package com.dife.api.model;
+
+public enum ChatRoomType {
+    GROUP,
+    SINGLE
+}

--- a/src/main/java/com/dife/api/model/dto/GroupChatRoomDto.java
+++ b/src/main/java/com/dife/api/model/dto/GroupChatRoomDto.java
@@ -1,0 +1,41 @@
+package com.dife.api.model.dto;
+
+import com.dife.api.model.ChatRoom;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "그룹 채팅방 응답 객체")
+public class GroupChatRoomDto {
+
+    @Schema(description = "그룹 채팅방 생성 성공여부", example = "true")
+    private Boolean success;
+
+    private Long groupChatRoomId;
+
+    @NotNull(message = "그룹 채팅방 이름을 입력해주세요!")
+    @Schema(description = "그룹 채팅방 이름", example = "21학번 모여라")
+    private String chatRoomName;
+
+    @NotNull(message = "그룹 채팅방의 한줄 소개를 입력해주세요!")
+    @Schema(description = "그룹 채팅방 한줄 소개", example = "21학번 정보 공유 및 잡담 채팅방")
+    private String chatRoomBio;
+
+    @Schema(description = "채팅방 생성 일시")
+    private LocalDateTime created;
+
+    public GroupChatRoomDto(ChatRoom chatRoom)
+    {
+        this.success = true;
+        this.groupChatRoomId = chatRoom.getId();
+        this.chatRoomName = chatRoom.getChatRoomName();
+        this.chatRoomBio = chatRoom.getChatRoomSetting().getChatRoomBio();
+        this.created = chatRoom.getCreated();
+    }
+}

--- a/src/main/java/com/dife/api/repository/ChatRoomRepository.java
+++ b/src/main/java/com/dife/api/repository/ChatRoomRepository.java
@@ -1,0 +1,11 @@
+package com.dife.api.repository;
+
+import com.dife.api.model.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    boolean existsByChatRoomName(String chatRoomName);
+}

--- a/src/main/java/com/dife/api/service/ChatRoomService.java
+++ b/src/main/java/com/dife/api/service/ChatRoomService.java
@@ -1,0 +1,65 @@
+package com.dife.api.service;
+
+import com.dife.api.exception.ChatRoomCountException;
+import com.dife.api.exception.ChatRoomDuplicateException;
+import com.dife.api.exception.ChatRoomException;
+import com.dife.api.model.*;
+import com.dife.api.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class ChatRoomService {
+
+    @Autowired
+    private final ChatRoomRepository chatRoomRepository;
+
+    public ChatRoom createGroupChatRoom(String chatRoomName, String chatRoomBio, String max_count, String min_count)
+    {
+        ChatRoom chatRoom = new ChatRoom();
+        if (chatRoomRepository.existsByChatRoomName(chatRoomName))
+        {
+            throw new ChatRoomDuplicateException();
+        }
+        if (chatRoomName == null || chatRoomName.isEmpty())
+        {
+            throw new ChatRoomException("채팅방 이름은 필수사항입니다.");
+        }
+        chatRoom.setChatRoomName(chatRoomName);
+        chatRoom.setChatRoomType(ChatRoomType.GROUP);
+
+        ChatRoomSetting chatRoomSetting = new ChatRoomSetting();
+
+        if (min_count == null || max_count == null || min_count.isEmpty() || max_count.isEmpty())
+        {
+            throw new ChatRoomException("채팅방 인원 설정은 필수사항입니다.");
+        }
+
+        int maxCount = Integer.parseInt(max_count);
+        int minCount = Integer.parseInt(min_count);
+        if (maxCount > 30 || minCount < 3)
+        {
+            throw new ChatRoomCountException();
+        }
+        chatRoomSetting.setMax_count(maxCount);
+        chatRoomSetting.setMin_count(minCount);
+
+        if (chatRoomBio == null || chatRoomBio.isEmpty())
+        {
+            throw new ChatRoomException("채팅방 이름은 필수사항입니다.");
+        }
+        chatRoomSetting.setChatRoomBio(chatRoomBio);
+
+        chatRoom.setChatRoomSetting(chatRoomSetting);
+
+        chatRoomRepository.save(chatRoom);
+
+        return chatRoom;
+    }
+}


### PR DESCRIPTION
### 개요
- 그룹 채팅방 생성 (HTTP) 및 채팅방 엔티티 세팅
- 기존에 ERD 설계시에 ChatRoomSetting에 포함되어 있던 필드값 중 ChatRoom의 필드값으로 뺀 사항 존재합니다!
ChatRoomType (채팅방 Type)
ChatRoomName (채팅방 이름)
- 파라미터로 Integer을 받아야 하는 사항 -> String으로 받은 후 서비스 단에서 Integer 변환처리 후 수정 및 DB 저장하는 방법을 사용했습니다!
- 세부 구현 사항 및 익셉션은 커밋 확인해주시면 됩니다!

### 테스트 확인

채팅방 생성
<img width="691" alt="스크린샷 2024-04-28 오후 6 35 51" src="https://github.com/team-diverse/dife-backend/assets/124496650/cceb3dd7-76bd-457e-83ff-18e9c81ab38a">

채팅방 생성 시에 중복된 채팅방 이름 존재 시 
<img width="691" alt="스크린샷 2024-04-28 오후 6 36 01" src="https://github.com/team-diverse/dife-backend/assets/124496650/963679e3-0a3f-4ab0-b95c-d04495d0b4b7">

채팅방 생성 시에 필수 입력사항 미충족 시
<img width="691" alt="스크린샷 2024-04-28 오후 6 35 40" src="https://github.com/team-diverse/dife-backend/assets/124496650/6b527edc-2df4-4e36-bbff-6585f591298a">


추후 진행사항
- Spring의 WebSocket을 적용한 그룹 채팅 생성