### PR TITLE
fix(docs): Swagger의 Configuration이 로드되지 않는 현상

### DIFF
--- a/src/main/java/com/dife/api/config/SecurityConfig.java
+++ b/src/main/java/com/dife/api/config/SecurityConfig.java
@@ -58,7 +58,7 @@ public class SecurityConfig {
 							requests
 									.requestMatchers(
 											"/swagger-ui/**",
-											"/api/v1/api-docs",
+											"/api/v1/api-docs/**",
 											"/api/chats/**",
 											"/api/members/register",
 											"/api/members/change-password",


### PR DESCRIPTION
### 개요

- 현재 서버에서 swagger-ui/index.html을 접속하면 documentation이 뜨지 않는다.

### 원인 및 해결

- 분석 결과, Swagger-UI는 내부적으로 OpenAPI 파일을 접근해야하는데, 그것이 서버 내부의 /api/v1/api-docs/swagger-config로 접근을 하지 못하여 로드가 안되는 것이다. 따라서, Security에서 해당 하위 경로 역시 allow 해준다.