### PR TITLE
Feat/chat group http implementation : 그룹 채팅방 생성 고도화

### DIFF
--- a/src/main/java/com/dife/api/controller/ChatController.java
+++ b/src/main/java/com/dife/api/controller/ChatController.java
@@ -1,41 +1,78 @@
 package com.dife.api.controller;
 
-import com.dife.api.model.Chatroom;
+import com.dife.api.model.*;
 import com.dife.api.model.dto.GroupChatroomRequestDto;
 import com.dife.api.model.dto.GroupChatroomResponseDto;
 import com.dife.api.service.ChatroomService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/api/chats")
 @Slf4j
-@Tag(name = "Chat API", description = "Chat API")
 public class ChatController {
 
 	private final ChatroomService chatroomService;
 
 	@Operation(summary = "그룹 채팅방 생성", description = "사용자가 그룹 채팅방 생성")
-	@PostMapping
-	public ResponseEntity<GroupChatroomResponseDto> createGroupChatroom(
-			@RequestBody(
-							description = "채팅방 이름, 한줄소개, 최소 인원수, 최대 인원수를 포함하는 그룹 채팅방 생성 데이터",
-							required = true,
-							content = @Content(schema = @Schema(implementation = GroupChatroomRequestDto.class)))
-					GroupChatroomRequestDto dto) {
+	@PostMapping(value = "/", consumes = "multipart/form-data")
+	@ApiResponse(
+			responseCode = "201",
+			description = "그룹 생성방1 성공 예시",
+			content = {
+				@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = GroupChatroomRequestDto.class))
+			})
+	public ResponseEntity<GroupChatroomRequestDto> createGroupChatroom(
+			@RequestParam(value = "name", required = false) String name,
+			@RequestParam("description") String description,
+			@RequestParam("profile_img") MultipartFile profile_img) {
 
-		Chatroom chatroom = chatroomService.createGroupChatroom(dto);
+		Chatroom chatroom = chatroomService.createGroupChatroom(name, description, profile_img);
 
+		return ResponseEntity.status(HttpStatus.CREATED).body(new GroupChatroomRequestDto(chatroom));
+	}
+
+	@PutMapping(value = "/{id}", consumes = "multipart/form-data")
+	@ApiResponse(
+			responseCode = "201",
+			description = "그룹 채팅방2 성공 예시",
+			content = {
+				@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = GroupChatroomResponseDto.class))
+			})
+	public ResponseEntity<GroupChatroomResponseDto> registerDetail(
+			@RequestParam(value = "tags", required = false) Set<String> tags,
+			@RequestParam(value = "min_count", required = false) Integer min_count,
+			@RequestParam(value = "max_count", required = false) Integer max_count,
+			@RequestParam(value = "languages", required = false) Set<String> languages,
+			@RequestParam(value = "purposes", required = false) Set<String> purposes,
+			@RequestParam(value = "is_public", required = false) Boolean is_public,
+			@RequestParam(value = "password", required = false) String password,
+			@PathVariable Long id) {
+
+		Chatroom chatroom =
+				chatroomService.registerDetail(
+						tags, min_count, max_count, languages, purposes, is_public, password, id);
 		return ResponseEntity.status(HttpStatus.CREATED).body(new GroupChatroomResponseDto(chatroom));
+	}
+
+	@GetMapping("/{id}")
+	public ResponseEntity<GroupChatroomResponseDto> getGroupChatroom(@PathVariable Long id) {
+		Chatroom chatroom = chatroomService.getChatroom(id);
+		return ResponseEntity.status(HttpStatus.OK).body(new GroupChatroomResponseDto(chatroom));
 	}
 }

--- a/src/main/java/com/dife/api/controller/ChatController.java
+++ b/src/main/java/com/dife/api/controller/ChatController.java
@@ -55,12 +55,12 @@ public class ChatController {
 						schema = @Schema(implementation = GroupChatroomResponseDto.class))
 			})
 	public ResponseEntity<GroupChatroomResponseDto> registerDetail(
-			@RequestParam(value = "tags", required = false) Set<String> tags,
-			@RequestParam(value = "min_count", required = false) Integer min_count,
-			@RequestParam(value = "max_count", required = false) Integer max_count,
-			@RequestParam(value = "languages", required = false) Set<String> languages,
-			@RequestParam(value = "purposes", required = false) Set<String> purposes,
-			@RequestParam(value = "is_public", required = false) Boolean is_public,
+			@RequestParam("tags") Set<String> tags,
+			@RequestParam("min_count") Integer min_count,
+			@RequestParam("max_count") Integer max_count,
+			@RequestParam("languages") Set<String> languages,
+			@RequestParam("purposes") Set<String> purposes,
+			@RequestParam("is_public") Boolean is_public,
 			@RequestParam(value = "password", required = false) String password,
 			@PathVariable Long id) {
 

--- a/src/main/java/com/dife/api/model/Chatroom.java
+++ b/src/main/java/com/dife/api/model/Chatroom.java
@@ -22,5 +22,7 @@ public class Chatroom extends BaseTimeEntity {
 
 	private ChatroomType chatroomType;
 
-	@Embedded private ChatroomSetting setting;
+	@OneToOne(cascade = CascadeType.ALL)
+	@JoinColumn(name = "crsetting_id")
+	private ChatroomSetting setting;
 }

--- a/src/main/java/com/dife/api/model/Chatroom.java
+++ b/src/main/java/com/dife/api/model/Chatroom.java
@@ -23,6 +23,6 @@ public class Chatroom extends BaseTimeEntity {
 	private ChatroomType chatroomType;
 
 	@OneToOne(cascade = CascadeType.ALL)
-	@JoinColumn(name = "crsetting_id")
-	private ChatroomSetting setting;
+	@JoinColumn(name = "chatroom_setting_id")
+	private ChatroomSetting chatroom_setting;
 }

--- a/src/main/java/com/dife/api/model/ChatroomSetting.java
+++ b/src/main/java/com/dife/api/model/ChatroomSetting.java
@@ -11,7 +11,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
-@Table(name = "crsetting")
+@Table(name = "chatroom_setting")
 public class ChatroomSetting {
 
 	@Id
@@ -22,16 +22,16 @@ public class ChatroomSetting {
 
 	@NotNull private String profile_img_name;
 
-	@OneToMany(mappedBy = "crsetting", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	@OneToMany(mappedBy = "chatroom_setting", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	private Set<Tag> tags;
 
 	private Integer min_count;
 	private Integer max_count;
 
-	@OneToMany(mappedBy = "crsetting", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	@OneToMany(mappedBy = "chatroom_setting", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	private Set<GroupPurpose> purposes;
 
-	@OneToMany(mappedBy = "crsetting", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	@OneToMany(mappedBy = "chatroom_setting", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	private Set<Language> languages;
 
 	private Boolean is_public;

--- a/src/main/java/com/dife/api/model/ChatroomSetting.java
+++ b/src/main/java/com/dife/api/model/ChatroomSetting.java
@@ -1,15 +1,42 @@
 package com.dife.api.model;
 
-import jakarta.persistence.Embeddable;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-@Embeddable
+@Entity
+@Table(name = "crsetting")
 public class ChatroomSetting {
 
-	private String description;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@NotNull private String description;
+
+	@NotNull private String profile_img_name;
+
+	@OneToMany(mappedBy = "crsetting", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	private Set<Tag> tags;
+
 	private Integer min_count;
 	private Integer max_count;
+
+	@OneToMany(mappedBy = "crsetting", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	private Set<GroupPurpose> purposes;
+
+	@OneToMany(mappedBy = "crsetting", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+	private Set<Language> languages;
+
+	private Boolean is_public;
+
+	@Size(min = 5, max = 5, message = "비밀번호는 정확히 5자 이어야 합니다.")
+	@Pattern(regexp = "^[0-9]{5}$", message = "비밀번호는 숫자 5자로 구성되어야 합니다.")
+	private String password;
 }

--- a/src/main/java/com/dife/api/model/GroupPurpose.java
+++ b/src/main/java/com/dife/api/model/GroupPurpose.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
-@Table(name = "grouppurpose")
+@Table(name = "group_purpose")
 public class GroupPurpose {
 
 	@Id
@@ -17,6 +17,6 @@ public class GroupPurpose {
 	private String name;
 
 	@ManyToOne
-	@JoinColumn(name = "crsetting_id")
-	private ChatroomSetting crsetting;
+	@JoinColumn(name = "chatroom_setting_id")
+	private ChatroomSetting chatroom_setting;
 }

--- a/src/main/java/com/dife/api/model/GroupPurpose.java
+++ b/src/main/java/com/dife/api/model/GroupPurpose.java
@@ -7,18 +7,14 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
-@Table(name = "language")
-public class Language {
+@Table(name = "grouppurpose")
+public class GroupPurpose {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	private String name;
-
-	@ManyToOne
-	@JoinColumn(name = "member_id")
-	private Member member;
 
 	@ManyToOne
 	@JoinColumn(name = "crsetting_id")

--- a/src/main/java/com/dife/api/model/Language.java
+++ b/src/main/java/com/dife/api/model/Language.java
@@ -21,6 +21,6 @@ public class Language {
 	private Member member;
 
 	@ManyToOne
-	@JoinColumn(name = "crsetting_id")
-	private ChatroomSetting crsetting;
+	@JoinColumn(name = "chatroom_setting_id")
+	private ChatroomSetting chatroom_setting;
 }

--- a/src/main/java/com/dife/api/model/Tag.java
+++ b/src/main/java/com/dife/api/model/Tag.java
@@ -7,18 +7,14 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
-@Table(name = "language")
-public class Language {
+@Table(name = "tag")
+public class Tag {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	private String name;
-
-	@ManyToOne
-	@JoinColumn(name = "member_id")
-	private Member member;
 
 	@ManyToOne
 	@JoinColumn(name = "crsetting_id")

--- a/src/main/java/com/dife/api/model/Tag.java
+++ b/src/main/java/com/dife/api/model/Tag.java
@@ -17,6 +17,6 @@ public class Tag {
 	private String name;
 
 	@ManyToOne
-	@JoinColumn(name = "crsetting_id")
-	private ChatroomSetting crsetting;
+	@JoinColumn(name = "chatroom_setting_id")
+	private ChatroomSetting chatroom_setting;
 }

--- a/src/main/java/com/dife/api/model/dto/GroupChatroomRequestDto.java
+++ b/src/main/java/com/dife/api/model/dto/GroupChatroomRequestDto.java
@@ -33,7 +33,7 @@ public class GroupChatroomRequestDto {
 		this.success = true;
 		this.roomId = chatroom.getId();
 		this.name = chatroom.getName();
-		this.description = chatroom.getSetting().getDescription();
-		this.profile_img_name = chatroom.getSetting().getProfile_img_name();
+		this.description = chatroom.getChatroom_setting().getDescription();
+		this.profile_img_name = chatroom.getChatroom_setting().getProfile_img_name();
 	}
 }

--- a/src/main/java/com/dife/api/model/dto/GroupChatroomRequestDto.java
+++ b/src/main/java/com/dife/api/model/dto/GroupChatroomRequestDto.java
@@ -1,9 +1,7 @@
 package com.dife.api.model.dto;
 
+import com.dife.api.model.Chatroom;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,21 +14,26 @@ import lombok.Setter;
 @Schema(description = "그룹 채팅방 생성 요청 객체")
 public class GroupChatroomRequestDto {
 
-	@NotNull(message = "그룹 채팅방 이름을 입력해주세요!")
+	@Schema(description = "채팅방 생성 성공여부", example = "true")
+	private Boolean success;
+
+	@Schema(description = "채팅방 고유번호", example = "1")
+	private Long roomId;
+
 	@Schema(description = "그룹 채팅방 이름", example = "21학번 모여라")
 	private String name;
 
-	@NotNull(message = "그룹 채팅방의 한줄 소개를 입력해주세요!")
 	@Schema(description = "그룹 채팅방 한줄 소개", example = "21학번 정보 공유 및 잡담 채팅방")
 	private String description;
 
-	@NotNull(message = "그룹 채팅방의 최대 인원수를 입력해주세요!")
-	@Max(value = 30, message = "최소 인원수는 30명 이하여야 합니다.")
-	@Schema(description = "그룹 채팅방 최대 인원수", example = "30")
-	private Integer max_count;
+	@Schema(description = "그룹 채팅방 프로필 사진 파일명", example = "cookie")
+	private String profile_img_name;
 
-	@NotNull(message = "그룹 채팅방의 최소 인원수를 입력해주세요!")
-	@Min(value = 3, message = "최소 인원수는 3명 이상이어야 합니다.")
-	@Schema(description = "그룹 채팅방 최소 인원수", example = "3")
-	private Integer min_count;
+	public GroupChatroomRequestDto(Chatroom chatroom) {
+		this.success = true;
+		this.roomId = chatroom.getId();
+		this.name = chatroom.getName();
+		this.description = chatroom.getSetting().getDescription();
+		this.profile_img_name = chatroom.getSetting().getProfile_img_name();
+	}
 }

--- a/src/main/java/com/dife/api/model/dto/GroupChatroomResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/GroupChatroomResponseDto.java
@@ -60,31 +60,34 @@ public class GroupChatroomResponseDto {
 		this.success = true;
 
 		this.name = chatroom.getName();
-		this.description = chatroom.getSetting().getDescription();
-		this.profile_img_name = chatroom.getSetting().getProfile_img_name();
+		this.description = chatroom.getChatroom_setting().getDescription();
+		this.profile_img_name = chatroom.getChatroom_setting().getProfile_img_name();
 		this.roomId = chatroom.getId();
-		if (chatroom.getSetting().getTags() != null && !chatroom.getSetting().getTags().isEmpty()) {
+		if (chatroom.getChatroom_setting().getTags() != null
+				&& !chatroom.getChatroom_setting().getTags().isEmpty()) {
 			this.tags =
-					chatroom.getSetting().getTags().stream().map(Tag::getName).collect(Collectors.toSet());
+					chatroom.getChatroom_setting().getTags().stream()
+							.map(Tag::getName)
+							.collect(Collectors.toSet());
 		}
-		this.min_count = chatroom.getSetting().getMin_count();
-		this.max_count = chatroom.getSetting().getMax_count();
-		if (chatroom.getSetting().getLanguages() != null
-				&& !chatroom.getSetting().getLanguages().isEmpty()) {
+		this.min_count = chatroom.getChatroom_setting().getMin_count();
+		this.max_count = chatroom.getChatroom_setting().getMax_count();
+		if (chatroom.getChatroom_setting().getLanguages() != null
+				&& !chatroom.getChatroom_setting().getLanguages().isEmpty()) {
 			this.languages =
-					chatroom.getSetting().getLanguages().stream()
+					chatroom.getChatroom_setting().getLanguages().stream()
 							.map(Language::getName)
 							.collect(Collectors.toSet());
 		}
-		if (chatroom.getSetting().getPurposes() != null
-				&& !chatroom.getSetting().getPurposes().isEmpty()) {
+		if (chatroom.getChatroom_setting().getPurposes() != null
+				&& !chatroom.getChatroom_setting().getPurposes().isEmpty()) {
 			this.purposes =
-					chatroom.getSetting().getPurposes().stream()
+					chatroom.getChatroom_setting().getPurposes().stream()
 							.map(GroupPurpose::getName)
 							.collect(Collectors.toSet());
 		}
-		this.is_public = chatroom.getSetting().getIs_public();
-		this.password = chatroom.getSetting().getPassword();
+		this.is_public = chatroom.getChatroom_setting().getIs_public();
+		this.password = chatroom.getChatroom_setting().getPassword();
 		this.created = chatroom.getCreated();
 	}
 }

--- a/src/main/java/com/dife/api/model/dto/GroupChatroomResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/GroupChatroomResponseDto.java
@@ -1,9 +1,13 @@
 package com.dife.api.model.dto;
 
 import com.dife.api.model.Chatroom;
+import com.dife.api.model.GroupPurpose;
+import com.dife.api.model.Language;
+import com.dife.api.model.Tag;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.*;
 
 @Getter
@@ -16,24 +20,71 @@ public class GroupChatroomResponseDto {
 	@Schema(description = "그룹 채팅방 생성 성공여부", example = "true")
 	private Boolean success;
 
+	@Schema(description = "채팅방 고유번호", example = "1")
 	private Long roomId;
 
-	@NotNull(message = "그룹 채팅방 이름을 입력해주세요!")
 	@Schema(description = "그룹 채팅방 이름", example = "21학번 모여라")
 	private String name;
 
-	@NotNull(message = "그룹 채팅방의 한줄 소개를 입력해주세요!")
-	@Schema(description = "그룹 채팅방 한줄 소개", example = "21학번 정보 공유 및 잡담 채팅방")
+	@Schema(description = "그룹 채팅방 생성 성공여부", example = "true")
 	private String description;
+
+	@Schema(description = "그룹 채팅방 프로필 사진 파일명", example = "cookie")
+	private String profile_img_name;
+
+	@Schema(description = "그룹 채팅방 태그", example = "cookie")
+	private Set<String> tags;
+
+	@Schema(description = "그룹 채팅방 최소 인원수", example = "3")
+	private Integer min_count;
+
+	@Schema(description = "그룹 채팅방 최대 인원수", example = "30")
+	private Integer max_count;
+
+	@Schema(description = "그룹 채팅방 설정 번역 언어", example = "Korean")
+	private Set<String> languages;
+
+	@Schema(description = "그룹 채팅방 목적", example = "communication, free")
+	private Set<String> purposes;
+
+	@Schema(description = "그룹 채팅방 공개/비공개 여부", example = "true")
+	private Boolean is_public;
+
+	@Schema(description = "그룹 채팅방 비밀번호", example = "00000")
+	private String password;
 
 	@Schema(description = "채팅방 생성 일시")
 	private LocalDateTime created;
 
 	public GroupChatroomResponseDto(Chatroom chatroom) {
 		this.success = true;
-		this.roomId = chatroom.getId();
+
 		this.name = chatroom.getName();
 		this.description = chatroom.getSetting().getDescription();
+		this.profile_img_name = chatroom.getSetting().getProfile_img_name();
+		this.roomId = chatroom.getId();
+		if (chatroom.getSetting().getTags() != null && !chatroom.getSetting().getTags().isEmpty()) {
+			this.tags =
+					chatroom.getSetting().getTags().stream().map(Tag::getName).collect(Collectors.toSet());
+		}
+		this.min_count = chatroom.getSetting().getMin_count();
+		this.max_count = chatroom.getSetting().getMax_count();
+		if (chatroom.getSetting().getLanguages() != null
+				&& !chatroom.getSetting().getLanguages().isEmpty()) {
+			this.languages =
+					chatroom.getSetting().getLanguages().stream()
+							.map(Language::getName)
+							.collect(Collectors.toSet());
+		}
+		if (chatroom.getSetting().getPurposes() != null
+				&& !chatroom.getSetting().getPurposes().isEmpty()) {
+			this.purposes =
+					chatroom.getSetting().getPurposes().stream()
+							.map(GroupPurpose::getName)
+							.collect(Collectors.toSet());
+		}
+		this.is_public = chatroom.getSetting().getIs_public();
+		this.password = chatroom.getSetting().getPassword();
 		this.created = chatroom.getCreated();
 	}
 }

--- a/src/main/java/com/dife/api/repository/GroupPurposesRepository.java
+++ b/src/main/java/com/dife/api/repository/GroupPurposesRepository.java
@@ -1,0 +1,8 @@
+package com.dife.api.repository;
+
+import com.dife.api.model.GroupPurpose;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GroupPurposesRepository extends JpaRepository<GroupPurpose, Long> {}

--- a/src/main/java/com/dife/api/repository/LanguageRepository.java
+++ b/src/main/java/com/dife/api/repository/LanguageRepository.java
@@ -5,7 +5,9 @@ import com.dife.api.model.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface LanguageRepository extends JpaRepository<Language, Long> {
 
 	Optional<Language> findByMemberAndName(

--- a/src/main/java/com/dife/api/repository/TagRepository.java
+++ b/src/main/java/com/dife/api/repository/TagRepository.java
@@ -1,0 +1,8 @@
+package com.dife.api.repository;
+
+import com.dife.api.model.*;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {}

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -55,7 +55,7 @@ public class ChatroomService {
 			setting.setProfile_img_name(null);
 		}
 
-		chatroom.setSetting(setting);
+		chatroom.setChatroom_setting(setting);
 
 		chatroomRepository.save(chatroom);
 
@@ -83,7 +83,7 @@ public class ChatroomService {
 			Long id) {
 		Chatroom chatroom = getChatroom(id);
 
-		ChatroomSetting setting = chatroom.getSetting();
+		ChatroomSetting setting = chatroom.getChatroom_setting();
 
 		Set<Tag> myTags = new HashSet<>();
 		if (tags == null || tags.isEmpty()) {
@@ -91,7 +91,7 @@ public class ChatroomService {
 		}
 		for (String tag : tags) {
 			Tag nTag = new Tag();
-			nTag.setCrsetting(setting);
+			nTag.setChatroom_setting(setting);
 			nTag.setName(tag);
 			tagRepository.save(nTag);
 			myTags.add(nTag);
@@ -114,7 +114,7 @@ public class ChatroomService {
 		for (String language : languages) {
 			Language nLanguage = new Language();
 			nLanguage.setName(language);
-			nLanguage.setCrsetting(setting);
+			nLanguage.setChatroom_setting(setting);
 			languageRepository.save(nLanguage);
 			myLanguages.add(nLanguage);
 		}
@@ -127,7 +127,7 @@ public class ChatroomService {
 		for (String purpose : purposes) {
 			GroupPurpose nPurpose = new GroupPurpose();
 			nPurpose.setName(purpose);
-			nPurpose.setCrsetting(setting);
+			nPurpose.setChatroom_setting(setting);
 			groupPurposesRepository.save(nPurpose);
 			myPurposes.add(nPurpose);
 		}

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -1,16 +1,20 @@
 package com.dife.api.service;
 
-import com.dife.api.exception.ChatroomCountException;
-import com.dife.api.exception.ChatroomDuplicateException;
-import com.dife.api.exception.ChatroomException;
+import com.dife.api.exception.*;
 import com.dife.api.model.*;
-import com.dife.api.model.dto.GroupChatroomRequestDto;
+import com.dife.api.model.dto.FileDto;
 import com.dife.api.repository.ChatroomRepository;
+import com.dife.api.repository.GroupPurposesRepository;
+import com.dife.api.repository.LanguageRepository;
+import com.dife.api.repository.TagRepository;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -19,13 +23,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatroomService {
 
 	@Autowired private final ChatroomRepository chatroomRepository;
+	private final TagRepository tagRepository;
+	private final LanguageRepository languageRepository;
+	private final GroupPurposesRepository groupPurposesRepository;
 
-	public Chatroom createGroupChatroom(GroupChatroomRequestDto dto) {
+	private final FileService fileService;
 
-		String name = dto.getName();
-		String description = dto.getDescription();
-		Integer max_count = dto.getMax_count();
-		Integer min_count = dto.getMin_count();
+	public Chatroom createGroupChatroom(String name, String description, MultipartFile profile_img) {
 
 		Chatroom chatroom = new Chatroom();
 		if (chatroomRepository.existsByName(name)) {
@@ -39,20 +43,17 @@ public class ChatroomService {
 
 		ChatroomSetting setting = new ChatroomSetting();
 
-		if (min_count == null || max_count == null) {
-			throw new ChatroomException("채팅방 인원 설정은 필수사항입니다.");
-		}
-
-		if (max_count > 30 || min_count < 3) {
-			throw new ChatroomCountException();
-		}
-		setting.setMax_count(max_count);
-		setting.setMin_count(min_count);
-
 		if (description == null || description.isEmpty()) {
-			throw new ChatroomException("채팅방 이름은 필수사항입니다.");
+			throw new ChatroomException("채팅방 한줄소개는 필수사항입니다.");
 		}
 		setting.setDescription(description);
+
+		if (profile_img != null && !profile_img.isEmpty()) {
+			FileDto profileImgPath = fileService.upload(profile_img);
+			setting.setProfile_img_name(profileImgPath.getName());
+		} else {
+			setting.setProfile_img_name(null);
+		}
 
 		chatroom.setSetting(setting);
 
@@ -64,5 +65,84 @@ public class ChatroomService {
 	public Boolean findChatroomById(Long id) {
 
 		return chatroomRepository.existsById(id);
+	}
+
+	public Chatroom getChatroom(Long id) {
+		Chatroom chatroom = chatroomRepository.findById(id).orElseThrow(ChatroomNotFoundException::new);
+		return chatroom;
+	}
+
+	public Chatroom registerDetail(
+			Set<String> tags,
+			Integer min_count,
+			Integer max_count,
+			Set<String> languages,
+			Set<String> purposes,
+			Boolean is_public,
+			String password,
+			Long id) {
+		Chatroom chatroom = getChatroom(id);
+
+		ChatroomSetting setting = chatroom.getSetting();
+
+		Set<Tag> myTags = new HashSet<>();
+		if (tags == null || tags.isEmpty()) {
+			throw new ChatroomException("채팅방 태그는 필수 입력사항입니다!");
+		}
+		for (String tag : tags) {
+			Tag nTag = new Tag();
+			nTag.setCrsetting(setting);
+			nTag.setName(tag);
+			tagRepository.save(nTag);
+			myTags.add(nTag);
+		}
+		setting.setTags(myTags);
+
+		if (min_count == null || max_count == null) {
+			throw new ChatroomException("채팅방 인원수는 필수 입력사항입니다!");
+		}
+		if (min_count < 3 || min_count > 30 || max_count < 3 || max_count > 30) {
+			throw new ChatroomException("채팅방 인원수 제한은 3~30명 입니다!");
+		}
+		setting.setMin_count(min_count);
+		setting.setMax_count(max_count);
+
+		Set<Language> myLanguages = new HashSet<>();
+		if (languages == null || languages.isEmpty()) {
+			throw new ChatroomException("채팅방 번역은 필수 입력사항입니다!");
+		}
+		for (String language : languages) {
+			Language nLanguage = new Language();
+			nLanguage.setName(language);
+			nLanguage.setCrsetting(setting);
+			languageRepository.save(nLanguage);
+			myLanguages.add(nLanguage);
+		}
+		setting.setLanguages(myLanguages);
+
+		Set<GroupPurpose> myPurposes = new HashSet<>();
+		if (purposes == null || purposes.isEmpty()) {
+			throw new ChatroomException("채팅방 목적은 필수 입력사항입니다!");
+		}
+		for (String purpose : purposes) {
+			GroupPurpose nPurpose = new GroupPurpose();
+			nPurpose.setName(purpose);
+			nPurpose.setCrsetting(setting);
+			groupPurposesRepository.save(nPurpose);
+			myPurposes.add(nPurpose);
+		}
+		setting.setPurposes(myPurposes);
+		if (is_public == null) {
+			throw new ChatroomException("공개/비공개 여부는 필수 입력사항입니다!");
+		}
+		setting.setIs_public(is_public);
+
+		if (password == null || !password.matches("^[0-9]{5}$")) {
+			throw new ChatroomException("비밀번호는 5자리 숫자여야 합니다!");
+		}
+		setting.setPassword(password);
+
+		chatroomRepository.save(chatroom);
+		return chatroom;
 	}
 }


### PR DESCRIPTION
### 개요
- #97 에서 생성한 초기 그룹 채팅방의 고도화
- 채팅방 세팅 @OneToMany 연결을 위한 엔티티 변경
- 채팅방 세부사항 관련 Class 생성
- 기존 단계별 회원가입 방법과 로직 동일
- 구체적인 구현 사항은 커밋 확인 부탁드립니다!

### 테스트 확인

#### 1. 그룹 채팅방1 생성
<img width="703" alt="스크린샷 2024-05-04 오후 7 18 08" src="https://github.com/team-diverse/dife-backend/assets/124496650/1ca2fea3-3e83-4e8f-aeaf-c7f98f1777d5">

#### 1. 그룹 채팅방2 생성
<img width="691" alt="스크린샷 2024-05-04 오후 7 18 27" src="https://github.com/team-diverse/dife-backend/assets/124496650/8bf8ccfe-7b84-46ca-b92d-a86fb0323810">


#### 추후 진행방향
STOMP 그룹 채팅방 고도화