### PR TITLE
refactor(jwt): JWTFilter를 로직 변경없이 Refactor

### DIFF
--- a/src/main/java/com/dife/api/jwt/JWTFilter.java
+++ b/src/main/java/com/dife/api/jwt/JWTFilter.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -19,16 +20,14 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
+@RequiredArgsConstructor
 public class JWTFilter extends OncePerRequestFilter {
+	private static final String AUTH_HEADER = "Authorization";
+	private static final String BEARER_TOKEN_PREFIX = "Bearer ";
+	private static final long TOKEN_VALIDITY_DURATION = 14 * 24 * 60 * 60 * 1000L;
 
 	private final JWTUtil jwtUtil;
 	private final MemberRepository memberRepository;
-
-	public JWTFilter(JWTUtil jwtUtil, MemberRepository memberRepository) {
-
-		this.jwtUtil = jwtUtil;
-		this.memberRepository = memberRepository;
-	}
 
 	@Override
 	protected void doFilterInternal(
@@ -36,64 +35,56 @@ public class JWTFilter extends OncePerRequestFilter {
 			throws ServletException, IOException {
 
 		String servletPath = request.getServletPath();
+
+		if (isExemptPath(servletPath)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
 		String token = jwtUtil.resolveToken(request);
 
-		if (servletPath.startsWith("/api/members/register")
+		try {
+			String email = jwtUtil.getEmail(token);
+			memberRepository.findByEmail(email).ifPresent(this::authenticateUser);
+			filterChain.doFilter(request, response);
+		} catch (ExpiredJwtException e) {
+			handleExpiredToken(e, response);
+			filterChain.doFilter(request, response);
+		} catch (JwtException | IllegalArgumentException | NoSuchElementException e) {
+			filterChain.doFilter(request, response);
+		}
+	}
+
+	private void authenticateUser(Member member) {
+		CustomUserDetails customUserDetails = new CustomUserDetails(member);
+		Authentication authentication =
+				new UsernamePasswordAuthenticationToken(
+						customUserDetails, null, customUserDetails.getAuthorities());
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+	}
+
+	private void handleExpiredToken(ExpiredJwtException e, HttpServletResponse response) {
+		String email = e.getClaims().get("email", String.class);
+		String role = e.getClaims().get("role", String.class);
+
+		String newToken = jwtUtil.createAccessJwt(email, role, TOKEN_VALIDITY_DURATION);
+
+		Optional<Member> optionalMember = memberRepository.findByEmail(email);
+
+		Member member = optionalMember.get();
+		member.setTokenId(newToken);
+		memberRepository.save(member);
+
+		response.setHeader(AUTH_HEADER, BEARER_TOKEN_PREFIX + newToken);
+	}
+
+	private boolean isExemptPath(String servletPath) {
+		return servletPath.startsWith("/api/members/register")
 				|| servletPath.equals("/api/members/change-password")
 				|| servletPath.equals("/api/members/login")
 				|| servletPath.startsWith("/swagger-ui")
 				|| servletPath.startsWith("/api/chat")
 				|| servletPath.startsWith("/ws")
-				|| servletPath.equals("/api/v1/api-docs")) {
-			filterChain.doFilter(request, response);
-			return;
-		}
-
-		try {
-			log.info("AceessToken : " + token);
-
-			String email = jwtUtil.getEmail(token);
-			Optional<Member> optionalMember = memberRepository.findByEmail(email);
-			Member member = optionalMember.get();
-
-			CustomUserDetails customUserDetails = new CustomUserDetails(member);
-			Authentication authentication =
-					new UsernamePasswordAuthenticationToken(
-							customUserDetails, null, customUserDetails.getAuthorities());
-			SecurityContextHolder.getContext().setAuthentication(authentication);
-
-			filterChain.doFilter(request, response);
-		} catch (ExpiredJwtException e) {
-			log.info("만료된 토큰");
-
-			String email = e.getClaims().get("email", String.class);
-			String role = e.getClaims().get("role", String.class);
-
-			String newToken = jwtUtil.createAccessJwt(email, role, 14 * 24 * 60 * 60 * 1000L);
-
-			Optional<Member> optionalMember = memberRepository.findByEmail(email);
-
-			Member member = optionalMember.get();
-			member.setTokenId(newToken);
-			memberRepository.save(member);
-
-			log.info("Refresh Token : " + member.getTokenId());
-
-			response.setHeader("Authorization", "Bearer " + newToken);
-			filterChain.doFilter(request, response);
-
-		} catch (JwtException | IllegalArgumentException e) {
-			log.error("유효하지 않은 토큰이 입력되었습니다.");
-			filterChain.doFilter(request, response);
-		} catch (NullPointerException e) {
-			log.info("사용자를 찾을 수 없습니다.");
-			filterChain.doFilter(request, response);
-		} catch (NoSuchElementException e) {
-			log.error("NoSuchElementException");
-			filterChain.doFilter(request, response);
-		} catch (ArrayIndexOutOfBoundsException e) {
-			log.error("토큰을 추출할 수 없습니다.");
-			filterChain.doFilter(request, response);
-		}
+				|| servletPath.equals("/api/v1/api-docs");
 	}
 }


### PR DESCRIPTION
### 개요

- 코드의 가독성을 위해 로직 변경 없이 코드를 refactoring하자

### 수정 사항

- lombok `@RequiredArgsConstructor` 어노테이션 사용
- 상수 앞으로 빼놓음
- 코드의 일부를 함수로 빼서 doFilterInternal의 가독성 올림
- 로깅 함수 삭제

### 참고

- 우선은 로직 변경 없이 코드 형식만 바꾸었습니다.