### PR TITLE
Feat/chat group stomp advancement : STOMP 입장, 세션관리 적용 고도화

### DIFF
--- a/src/main/java/com/dife/api/controller/ChatController.java
+++ b/src/main/java/com/dife/api/controller/ChatController.java
@@ -15,7 +15,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @Controller
 @RequiredArgsConstructor
@@ -37,10 +36,9 @@ public class ChatController {
 			})
 	public ResponseEntity<GroupChatroomRequestDto> createGroupChatroom(
 			@RequestParam(value = "name", required = false) String name,
-			@RequestParam("description") String description,
-			@RequestParam("profile_img") MultipartFile profile_img) {
+			@RequestParam("description") String description) {
 
-		Chatroom chatroom = chatroomService.createGroupChatroom(name, description, profile_img);
+		Chatroom chatroom = chatroomService.createGroupChatroom(name, description);
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(new GroupChatroomRequestDto(chatroom));
 	}
@@ -56,7 +54,6 @@ public class ChatController {
 			})
 	public ResponseEntity<GroupChatroomResponseDto> registerDetail(
 			@RequestParam("tags") Set<String> tags,
-			@RequestParam("min_count") Integer min_count,
 			@RequestParam("max_count") Integer max_count,
 			@RequestParam("languages") Set<String> languages,
 			@RequestParam("purposes") Set<String> purposes,
@@ -66,7 +63,7 @@ public class ChatController {
 
 		Chatroom chatroom =
 				chatroomService.registerDetail(
-						tags, min_count, max_count, languages, purposes, is_public, password, id);
+						tags, max_count, languages, purposes, is_public, password, id);
 		return ResponseEntity.status(HttpStatus.CREATED).body(new GroupChatroomResponseDto(chatroom));
 	}
 

--- a/src/main/java/com/dife/api/controller/SocketController.java
+++ b/src/main/java/com/dife/api/controller/SocketController.java
@@ -1,11 +1,13 @@
 package com.dife.api.controller;
 
 import com.dife.api.model.dto.ChatDto;
+import com.dife.api.model.dto.ChatEnterDto;
 import com.dife.api.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
@@ -36,9 +38,15 @@ public class SocketController {
 		log.info("세션 연결 끊김 by EventListener : {}", sessionId);
 	}
 
-	@MessageMapping("/chatroom/{id}")
+	@MessageMapping("/chatroom/enter/{id}")
 	@SendTo("/topic/chatroom")
-	public void sendMessage(@DestinationVariable("id") Long id, ChatDto dto) {
+	public void sendEnter(
+			@DestinationVariable("id") Long id,
+			ChatEnterDto dto,
+			@Header("simpSessionId") String sessionId) {
+
+		chatService.sendEnter(id, dto, sessionId);
+	}
 
 		chatService.sendMessage(id, dto);
 	}

--- a/src/main/java/com/dife/api/model/Chatroom.java
+++ b/src/main/java/com/dife/api/model/Chatroom.java
@@ -1,6 +1,8 @@
 package com.dife.api.model;
 
 import jakarta.persistence.*;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +23,9 @@ public class Chatroom extends BaseTimeEntity {
 	private String name;
 
 	private ChatroomType chatroomType;
+
+	@ElementCollection(fetch = FetchType.EAGER)
+	private Map<String, Boolean> activeSessions = new ConcurrentHashMap<>();
 
 	@OneToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "chatroom_setting_id")

--- a/src/main/java/com/dife/api/model/ChatroomSetting.java
+++ b/src/main/java/com/dife/api/model/ChatroomSetting.java
@@ -20,12 +20,12 @@ public class ChatroomSetting {
 
 	@NotNull private String description;
 
-	@NotNull private String profile_img_name;
+	private String profile_img_name;
 
 	@OneToMany(mappedBy = "chatroom_setting", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
 	private Set<Tag> tags;
 
-	private Integer min_count;
+	private Integer count = 0;
 	private Integer max_count;
 
 	@OneToMany(mappedBy = "chatroom_setting", cascade = CascadeType.ALL, fetch = FetchType.EAGER)

--- a/src/main/java/com/dife/api/model/dto/ChatEnterDto.java
+++ b/src/main/java/com/dife/api/model/dto/ChatEnterDto.java
@@ -1,0 +1,15 @@
+package com.dife.api.model.dto;
+
+import com.dife.api.model.ChatType;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatEnterDto {
+
+	private ChatType chatType;
+	private String password;
+	private Long chatroom_id;
+	private String sender;
+}

--- a/src/main/java/com/dife/api/model/dto/GroupChatroomResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/GroupChatroomResponseDto.java
@@ -35,9 +35,6 @@ public class GroupChatroomResponseDto {
 	@Schema(description = "그룹 채팅방 태그", example = "cookie")
 	private Set<String> tags;
 
-	@Schema(description = "그룹 채팅방 최소 인원수", example = "3")
-	private Integer min_count;
-
 	@Schema(description = "그룹 채팅방 최대 인원수", example = "30")
 	private Integer max_count;
 
@@ -70,7 +67,6 @@ public class GroupChatroomResponseDto {
 							.map(Tag::getName)
 							.collect(Collectors.toSet());
 		}
-		this.min_count = chatroom.getChatroom_setting().getMin_count();
 		this.max_count = chatroom.getChatroom_setting().getMax_count();
 		if (chatroom.getChatroom_setting().getLanguages() != null
 				&& !chatroom.getChatroom_setting().getLanguages().isEmpty()) {

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -1,15 +1,19 @@
 package com.dife.api.service;
 
-import com.dife.api.exception.ChatroomNotFoundException;
 import com.dife.api.model.ChatType;
 import com.dife.api.model.Chatroom;
+import com.dife.api.model.ChatroomSetting;
 import com.dife.api.model.dto.ChatDto;
+import com.dife.api.model.dto.ChatEnterDto;
+import com.dife.api.repository.ChatroomRepository;
 import jakarta.annotation.PostConstruct;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -20,6 +24,7 @@ public class ChatService {
 	private Map<Long, Chatroom> chatrooms;
 	private final SimpMessageSendingOperations messagingTemplate;
 	private final ChatroomService chatroomService;
+	private final ChatroomRepository chatroomRepository;
 
 	@PostConstruct
 	private void init() {
@@ -28,9 +33,40 @@ public class ChatService {
 
 	public void sendMessage(Long room_id, ChatDto dto) {
 
+	public void enter(Long room_id, String session_id, ChatEnterDto dto) {
 		Boolean is_valid = chatroomService.findChatroomById(room_id);
-		if (is_valid) {
-			if (dto.getChatType() == ChatType.ENTER) {
+		if (!is_valid) {
+			disconnectSession(room_id, session_id);
+			log.warn("유효한 채팅방이 아닙니다!");
+			return;
+		}
+		if (dto.getChatType() != ChatType.ENTER) {
+			disconnectSession(room_id, session_id);
+			log.warn("해당 접근은 ENTER에 한해 유효합니다!");
+			return;
+		}
+
+		Chatroom chatroom = chatroomService.getChatroom(room_id);
+		if (chatroomService.isFull(chatroom)) {
+			disconnectSession(room_id, session_id);
+			log.warn("이미 해당 채팅방은 다 찬 채팅방입니다!");
+			return;
+		}
+		if (chatroomService.isWrongPassword(chatroom, dto.getPassword())) {
+			disconnectSession(room_id, session_id);
+			log.warn("채팅방 비밀번호가 틀렸습니다! 다시 시도해주세요!");
+			return;
+		}
+
+		Map<String, Boolean> activeSessions = chatroom.getActiveSessions();
+
+		synchronized (activeSessions) {
+			if (!activeSessions.containsKey(session_id)) {
+				activeSessions.put(session_id, true);
+				ChatroomSetting setting = chatroom.getChatroom_setting();
+				Integer nCount = setting.getCount();
+				nCount++;
+				setting.setCount(nCount);
 				messagingTemplate.convertAndSend(
 						"/topic/chatroom/" + room_id, dto.getSender() + "님이 입장하셨습니다!");
 			}

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -2,7 +2,6 @@ package com.dife.api.service;
 
 import com.dife.api.exception.*;
 import com.dife.api.model.*;
-import com.dife.api.model.dto.FileDto;
 import com.dife.api.repository.ChatroomRepository;
 import com.dife.api.repository.GroupPurposesRepository;
 import com.dife.api.repository.LanguageRepository;
@@ -14,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +27,7 @@ public class ChatroomService {
 
 	private final FileService fileService;
 
-	public Chatroom createGroupChatroom(String name, String description, MultipartFile profile_img) {
+	public Chatroom createGroupChatroom(String name, String description) {
 
 		Chatroom chatroom = new Chatroom();
 		if (chatroomRepository.existsByName(name)) {
@@ -47,13 +45,6 @@ public class ChatroomService {
 			throw new ChatroomException("채팅방 한줄소개는 필수사항입니다.");
 		}
 		setting.setDescription(description);
-
-		if (profile_img != null && !profile_img.isEmpty()) {
-			FileDto profileImgPath = fileService.upload(profile_img);
-			setting.setProfile_img_name(profileImgPath.getName());
-		} else {
-			setting.setProfile_img_name(null);
-		}
 
 		chatroom.setChatroom_setting(setting);
 
@@ -74,7 +65,6 @@ public class ChatroomService {
 
 	public Chatroom registerDetail(
 			Set<String> tags,
-			Integer min_count,
 			Integer max_count,
 			Set<String> languages,
 			Set<String> purposes,
@@ -98,13 +88,9 @@ public class ChatroomService {
 		}
 		setting.setTags(myTags);
 
-		if (min_count == null || max_count == null) {
-			throw new ChatroomException("채팅방 인원수는 필수 입력사항입니다!");
-		}
-		if (min_count < 3 || min_count > 30 || max_count < 3 || max_count > 30) {
+		if (max_count == null || max_count > 30) {
 			throw new ChatroomException("채팅방 인원수 제한은 3~30명 입니다!");
 		}
-		setting.setMin_count(min_count);
 		setting.setMax_count(max_count);
 
 		Set<Language> myLanguages = new HashSet<>();

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -131,4 +131,24 @@ public class ChatroomService {
 		chatroomRepository.save(chatroom);
 		return chatroom;
 	}
+
+	public Boolean isFull(Chatroom chatroom) {
+		ChatroomSetting setting = chatroom.getChatroom_setting();
+		Integer maxCount = setting.getMax_count();
+		Integer nCount = setting.getCount();
+		if (nCount >= maxCount) {
+			return true;
+		}
+		return false;
+	}
+
+	public Boolean isWrongPassword(Chatroom chatroom, String given_password) {
+		ChatroomSetting setting = chatroom.getChatroom_setting();
+		String password = setting.getPassword();
+
+		if (!password.equals(given_password)) {
+			return true;
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
### 개요
- #100 에서 구현한 STOMP 입장, 채팅 고도화한 PR입니다!
- 주요 구현사항은 커밋별 확인 부탁드립니다!

### 주요 변경사항

STOMP 사용임에도 채팅방이 꽉 찼는지, 입장해있는 세션에 한해 CHAT, EXIT을 구현, 서버에서 세션을 끊는 구현을 하기 위해서는 
채팅방에 입장한 세션정보 저장은 불가피하다고 판단함
- Chatroom에서 접속해있는 세션들을 접속해있는 상태와 세션ID를 Map 형태로 저장
- ChatroomSetting에서 ENTER시 카운트하는 변수 추가

1. min_count 삭제 -> setting의 count로 현재 접속해있는 세션 갯수 세기 진행 및 full 여부 판단함
2. 입장, (채팅, 퇴장) pub 엔드포인트 분리
3. 현재 접속해있는 세션 정보를 @Header("simpleSessionId")를 통해 받아오기
4. 받아온 세션 정보를 이용해 서버에서 세션 종료 구현
5. 채팅방의 full 여부, 비밀번호 불일치 여부 구현

### 채팅방 입장 로직

#### 1.  채팅방 입장에서의 유효성 확인

- 만들어진 채팅방인지
- ENTER 접근인지
- 채팅방이 꽉찬 채팅방인지
- 비밀번호가 틀렸는지

→ 세션 끊음

- 접속해있는 회원인지 확인

→ 세션 유지

#### 2.  유효성 확인 후 Map에 입장한 세션 추가 후 입장 메시지 발행

### 테스트 방법
https://apic.app/online/#/tester

#### 1. 채팅방 입장
- /app/chatroom/enter/1
<img width="1109" alt="스크린샷 2024-05-07 오후 6 00 19" src="https://github.com/team-diverse/dife-backend/assets/124496650/0ae61bcf-7d82-475d-b1bf-32fd16533b11">

#### 1-1. 채팅방 입장 실패 - full 상태 

<img width="1108" alt="스크린샷 2024-05-07 오후 6 01 48" src="https://github.com/team-diverse/dife-backend/assets/124496650/3cc9b21d-ebf1-46b4-99f9-13ef23fdece2">
<img width="500" alt="스크린샷 2024-05-07 오후 6 21 55" src="https://github.com/team-diverse/dife-backend/assets/124496650/4f144ddc-6b1d-4073-975a-b27041f2d3d3">
<img width="1147" alt="스크린샷 2024-05-07 오후 6 22 01" src="https://github.com/team-diverse/dife-backend/assets/124496650/656b9dcd-faed-4fdd-b9fc-38c49176d48a">



#### 1-2. 채팅방 입장 실패 - password 오류

<img width="1108" alt="스크린샷 2024-05-07 오후 6 01 48" src="https://github.com/team-diverse/dife-backend/assets/124496650/3cc9b21d-ebf1-46b4-99f9-13ef23fdece2">
<img width="1364" alt="스크린샷 2024-05-07 오후 6 01 55" src="https://github.com/team-diverse/dife-backend/assets/124496650/8fe16183-ccc9-4738-86ab-47cb8b37d602">
