### PR TITLE
Feat/chat group chat advancement : STOMP Chat DB 저장 도입

### DIFF
--- a/src/main/java/com/dife/api/controller/ChatroomController.java
+++ b/src/main/java/com/dife/api/controller/ChatroomController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/chats")
 @Slf4j
-public class ChatController {
+public class ChatroomController {
 
 	private final ChatroomService chatroomService;
 

--- a/src/main/java/com/dife/api/model/Chat.java
+++ b/src/main/java/com/dife/api/model/Chat.java
@@ -1,0 +1,32 @@
+package com.dife.api.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "chat")
+public class Chat {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@NotNull
+	@Size(max = 300)
+	private String message;
+
+	@ManyToOne
+	@JoinColumn(name = "chatroom_id")
+	private Chatroom chatroom;
+
+	private String sender;
+}

--- a/src/main/java/com/dife/api/model/Chatroom.java
+++ b/src/main/java/com/dife/api/model/Chatroom.java
@@ -2,6 +2,7 @@ package com.dife.api.model;
 
 import jakarta.persistence.*;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -30,4 +31,7 @@ public class Chatroom extends BaseTimeEntity {
 	@OneToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "chatroom_setting_id")
 	private ChatroomSetting chatroom_setting;
+
+	@OneToMany(mappedBy = "chatroom")
+	private Set<Chat> chats;
 }

--- a/src/main/java/com/dife/api/model/ChatroomSetting.java
+++ b/src/main/java/com/dife/api/model/ChatroomSetting.java
@@ -18,7 +18,9 @@ public class ChatroomSetting {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@NotNull private String description;
+	@NotNull
+	@Size(max = 60)
+	private String description;
 
 	private String profile_img_name;
 

--- a/src/main/java/com/dife/api/repository/ChatRepository.java
+++ b/src/main/java/com/dife/api/repository/ChatRepository.java
@@ -1,0 +1,6 @@
+package com.dife.api.repository;
+
+import com.dife.api.model.Chat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRepository extends JpaRepository<Chat, Long> {}

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -101,7 +101,7 @@ public class ChatService {
 		}
 
 		if (dto.getMessage().length() > 300) {
-			messagingTemplate.convertAndSendToUser(dto.getSender(),"/queue/" + dto.getSender(), "메시지는 300자 이내로 입력하셔야 합니다.");
+			messagingTemplate.convertAndSend("/topic/chatroom/" + room_id, "메시지는 300자 이내로 입력하셔야 합니다.");
 		} else {
 			Chat chat = new Chat();
 			chat.setMessage(dto.getMessage());

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -1,10 +1,12 @@
 package com.dife.api.service;
 
+import com.dife.api.model.Chat;
 import com.dife.api.model.ChatType;
 import com.dife.api.model.Chatroom;
 import com.dife.api.model.ChatroomSetting;
 import com.dife.api.model.dto.ChatDto;
 import com.dife.api.model.dto.ChatEnterDto;
+import com.dife.api.repository.ChatRepository;
 import com.dife.api.repository.ChatroomRepository;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ public class ChatService {
 	private final SimpMessageSendingOperations messagingTemplate;
 	private final ChatroomService chatroomService;
 	private final ChatroomRepository chatroomRepository;
+	private final ChatRepository chatRepository;
 
 	public void sendEnter(Long room_id, ChatEnterDto dto, String session_id) {
 		enter(room_id, session_id, dto);
@@ -98,7 +101,7 @@ public class ChatService {
 		}
 
 		if (dto.getMessage().length() > 300) {
-			messagingTemplate.convertAndSend("/topic/chatroom/" + room_id, "메시지는 300자 이내로 입력하셔야 합니다.");
+			messagingTemplate.convertAndSendToUser(dto.getSender(),"/queue/" + dto.getSender(), "메시지는 300자 이내로 입력하셔야 합니다.");
 		} else {
 			Chat chat = new Chat();
 			chat.setMessage(dto.getMessage());

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -97,7 +97,17 @@ public class ChatService {
 			return;
 		}
 
-		messagingTemplate.convertAndSend("/topic/chatroom/" + room_id, dto.getMessage());
+		if (dto.getMessage().length() > 300) {
+			messagingTemplate.convertAndSend("/topic/chatroom/" + room_id, "메시지는 300자 이내로 입력하셔야 합니다.");
+		} else {
+			Chat chat = new Chat();
+			chat.setMessage(dto.getMessage());
+			chat.setChatroom(chatroom);
+			chat.setSender(dto.getSender());
+
+			chatRepository.save(chat);
+			messagingTemplate.convertAndSend("/topic/chatroom/" + room_id, dto.getMessage());
+		}
 	}
 
 	public void exit(Long room_id, String session_id, ChatDto dto) {

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -36,7 +36,8 @@ public class ChatroomService {
 		if (name == null || name.isEmpty()) {
 			throw new ChatroomException("채팅방 이름은 필수사항입니다.");
 		}
-		chatroom.setName(name);
+		String trimmedName = name.trim();
+		chatroom.setName(trimmedName);
 		chatroom.setChatroomType(ChatroomType.GROUP);
 
 		ChatroomSetting setting = new ChatroomSetting();
@@ -44,6 +45,16 @@ public class ChatroomService {
 		if (description == null || description.isEmpty()) {
 			throw new ChatroomException("채팅방 한줄소개는 필수사항입니다.");
 		}
+
+		if (description.length() > 60) {
+			throw new ChatroomException("채팅방 한줄소개는 60자 이내입니다.");
+		}
+
+		String trimmedDescription = description.trim();
+		if (trimmedDescription.isEmpty()) {
+			throw new ChatroomException("유효하지 않은 한줄소개입니다. 공백만 존재하는 한줄 소개는 허용되지 않습니다.");
+		}
+
 		setting.setDescription(description);
 
 		chatroom.setChatroom_setting(setting);
@@ -88,14 +99,14 @@ public class ChatroomService {
 		}
 		setting.setTags(myTags);
 
-		if (max_count == null || max_count > 30) {
+		if (max_count > 30) {
 			throw new ChatroomException("채팅방 인원수 제한은 3~30명 입니다!");
 		}
 		setting.setMax_count(max_count);
 
 		Set<Language> myLanguages = new HashSet<>();
 		if (languages == null || languages.isEmpty()) {
-			throw new ChatroomException("채팅방 번역은 필수 입력사항입니다!");
+			throw new ChatroomException("채팅방 번역 언어 선택은 필수 입력사항입니다!");
 		}
 		for (String language : languages) {
 			Language nLanguage = new Language();
@@ -118,15 +129,14 @@ public class ChatroomService {
 			myPurposes.add(nPurpose);
 		}
 		setting.setPurposes(myPurposes);
-		if (is_public == null) {
-			throw new ChatroomException("공개/비공개 여부는 필수 입력사항입니다!");
-		}
 		setting.setIs_public(is_public);
 
-		if (password == null || !password.matches("^[0-9]{5}$")) {
-			throw new ChatroomException("비밀번호는 5자리 숫자여야 합니다!");
+		if (!is_public) {
+			if (password == null || !password.matches("^[0-9]{5}$")) {
+				throw new ChatroomException("비밀번호는 5자리 숫자여야 합니다!");
+			}
+			setting.setPassword(password);
 		}
-		setting.setPassword(password);
 
 		chatroomRepository.save(chatroom);
 		return chatroom;

--- a/src/test/java/com/dife/api/controller/ChatroomControllerTest.java
+++ b/src/test/java/com/dife/api/controller/ChatroomControllerTest.java
@@ -1,0 +1,177 @@
+package com.dife.api.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dife.api.GlobalExceptionHandler;
+import com.dife.api.exception.ChatroomDuplicateException;
+import com.dife.api.exception.ChatroomException;
+import com.dife.api.model.Chatroom;
+import com.dife.api.model.ChatroomSetting;
+import com.dife.api.model.ChatroomType;
+import com.dife.api.model.dto.GroupChatroomRequestDto;
+import com.dife.api.service.ChatroomService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+public class ChatroomControllerTest {
+
+	private MockMvc mockMvc;
+
+	@Mock private ChatroomService chatroomService;
+
+	@InjectMocks private ChatroomController chatroomController;
+
+	@BeforeEach
+	public void setUp() {
+		mockMvc =
+				MockMvcBuilders.standaloneSetup(chatroomController)
+						.setControllerAdvice(new GlobalExceptionHandler())
+						.build();
+	}
+
+	@Test
+	public void createGroupChatroom_ShouldReturn_201_WhenNameAndDescriptionIsPassed()
+			throws Exception {
+
+		String name = "exampleChatroomName";
+		String description = "exampleDescription";
+
+		Chatroom chatroom = new Chatroom();
+		chatroom.setId(1L);
+		chatroom.setName(name);
+		chatroom.setChatroomType(ChatroomType.GROUP);
+
+		ChatroomSetting setting = new ChatroomSetting();
+		setting.setDescription(description);
+		chatroom.setChatroom_setting(setting);
+
+		GroupChatroomRequestDto requestDto = new GroupChatroomRequestDto(chatroom);
+		String reqBody = new ObjectMapper().writeValueAsString(requestDto);
+
+		given(chatroomService.createGroupChatroom(name, description)).willReturn(chatroom);
+		mockMvc
+				.perform(
+						post("/api/chats/")
+								.param("name", name)
+								.param("description", description)
+								.contentType(MediaType.MULTIPART_FORM_DATA)
+								.content(reqBody))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.roomId").value(chatroom.getId()))
+				.andExpect(jsonPath("$.name").value("exampleChatroomName"))
+				.andExpect(jsonPath("$.description").value("exampleDescription"));
+	}
+
+	@Test
+	public void createGroupChatroom_ShouldReturn_409_WhenNameExists() throws Exception {
+		String name = "exampleChatroomName";
+		String description = "exampleDescription";
+
+		Chatroom chatroom = new Chatroom();
+		chatroom.setId(1L);
+		chatroom.setName(name);
+		chatroom.setChatroomType(ChatroomType.GROUP);
+
+		ChatroomSetting setting = new ChatroomSetting();
+		setting.setDescription(description);
+		chatroom.setChatroom_setting(setting);
+
+		GroupChatroomRequestDto requestDto = new GroupChatroomRequestDto(chatroom);
+		String reqBody = new ObjectMapper().writeValueAsString(requestDto);
+
+		when(chatroomService.createGroupChatroom(requestDto.getName(), requestDto.getDescription()))
+				.thenThrow(new ChatroomDuplicateException());
+
+		mockMvc
+				.perform(
+						post("/api/chats/")
+								.param("name", name)
+								.param("description", description)
+								.contentType(MediaType.MULTIPART_FORM_DATA)
+								.content(reqBody))
+				.andExpect(status().isConflict())
+				.andExpect(jsonPath("$.success").value(false));
+	}
+
+	@Test
+	public void createGroupChatroom_ShouldReturn_422_WhenNameIsNull() throws Exception {
+		String name = "";
+		String description = "exampleDescription";
+
+		Chatroom chatroom = new Chatroom();
+		chatroom.setId(1L);
+		chatroom.setName(name);
+		chatroom.setChatroomType(ChatroomType.GROUP);
+
+		ChatroomSetting setting = new ChatroomSetting();
+		setting.setDescription(description);
+		chatroom.setChatroom_setting(setting);
+
+		GroupChatroomRequestDto requestDto = new GroupChatroomRequestDto(chatroom);
+		String reqBody = new ObjectMapper().writeValueAsString(requestDto);
+
+		when(chatroomService.createGroupChatroom(requestDto.getName(), requestDto.getDescription()))
+				.thenThrow(new ChatroomException("채팅방 이름은 필수 사항입니다."));
+
+		mockMvc
+				.perform(
+						post("/api/chats/")
+								.param("name", name)
+								.param("description", description)
+								.contentType(MediaType.MULTIPART_FORM_DATA)
+								.content(reqBody))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.success").value(false));
+	}
+
+	@Test
+	public void createGroupChatroom_ShouldReturn_422_WhenDescriptionIsNull() throws Exception {
+		String name = "exampleChatroomName";
+		String description = "";
+
+		Chatroom chatroom = new Chatroom();
+		chatroom.setId(1L);
+		chatroom.setName(name);
+		chatroom.setChatroomType(ChatroomType.GROUP);
+
+		ChatroomSetting setting = new ChatroomSetting();
+		setting.setDescription(description);
+		chatroom.setChatroom_setting(setting);
+
+		GroupChatroomRequestDto requestDto = new GroupChatroomRequestDto(chatroom);
+		String reqBody = new ObjectMapper().writeValueAsString(requestDto);
+
+		when(chatroomService.createGroupChatroom(requestDto.getName(), requestDto.getDescription()))
+				.thenThrow(new ChatroomException("채팅방 한줄 소개는 필수 사항입니다."));
+
+		mockMvc
+				.perform(
+						post("/api/chats/")
+								.param("name", name)
+								.param("description", description)
+								.contentType(MediaType.MULTIPART_FORM_DATA)
+								.content(reqBody))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.success").value(false));
+	}
+
+	@Test
+	void registerDetail() {}
+
+	@Test
+	void getGroupChatroom() {}
+}


### PR DESCRIPTION
### 개요
- 기존 만들어 둔 채팅 서비스를 이용한 채팅 DB 저장 PR입니다!
- 300자 이내로 작성된 채팅은 저장되도록 구현했습니다!
- 채팅서비스에서 고려해야 하는 제한사항 추가해두었습니다!
- 자세한 사항은 커밋별 확인 부탁드립니다!

### 테스트 확인

#### 300자 이내의 유효한 채팅에 한해 저장


#### 1. 300자 초과할 경우
```
{
    "chatType" : "CHAT",
    "chatroom_id" : 1,
    "message": "오늘의 날씨는 매우 맑고 화창하여 외출하기에 좋은 날씨입니다. 주말 동안 친구들과 함께 산책을 하거나 가벼운 운동을 즐기기에도 좋겠습니다. 이와 동시에, 최근에 읽은 책 '시간의 흐름 속에서'는 인간의 삶과 시간에 대한 깊은 통찰을 제공하며, 많은 생각을 하게 만드는 책이었습니다. 책에서는 시간을 어떻게 인식하고 활용하는지에 대한 여러 관점을 탐구하고 있어 매우 흥미롭습니다. 우리는 종종 바쁜 일상 속에서 시간의 중요성을 잊곤 하지만, 이 책을 통해 시간을 소중히 여기고 더 의미 있게 사용하는 방법에 대해 다시 생각하게 됩니다.   ",
    "sender" : "sooya"
}
```

<img width="1123" alt="스크린샷 2024-05-10 오후 6 02 07" src="https://github.com/team-diverse/dife-backend/assets/124496650/5fc57d4f-a504-4c40-86c1-1963a3a1bd67">

<img width="482" alt="스크린샷 2024-05-10 오후 6 09 08" src="https://github.com/team-diverse/dife-backend/assets/124496650/098c41cb-1f25-484c-b1e9-337182194196">

#### 적용사항 (로직 변경 X)

#### - 제목 trim
<img width="700" alt="스크린샷 2024-05-10 오후 6 59 28" src="https://github.com/team-diverse/dife-backend/assets/124496650/2a1cf319-615e-4e84-ba5e-f7078e186eae">



#### - 한줄소개 공백만 작성 불가하게
<img width="700" alt="스크린샷 2024-05-10 오후 3 51 15" src="https://github.com/team-diverse/dife-backend/assets/124496650/6bf144e7-fc53-4f4d-b85d-64ad959dfbbc">



#### - 한줄소개 60자 이내
<img width="700" alt="스크린샷 2024-05-10 오후 3 33 12" src="https://github.com/team-diverse/dife-backend/assets/124496650/f2da171d-9301-4189-8a8c-76a4c58c06aa">


#### - 비공개 채팅방에 한해 비밀번호 설정
<img width="700" alt="스크린샷 2024-05-10 오후 3 52 20" src="https://github.com/team-diverse/dife-backend/assets/124496650/7600d3ea-d5da-4ab7-9613-981c0d3bfbf0">


#### 추후진행사항
- Redis 적용 범위 고민