### PR TITLE
Refactor/login onboading : 온보딩 과정을 고려한 로그인 성공 시 보여질 값 추가

### DIFF
--- a/src/main/java/com/dife/api/config/SwaggerConfig.java
+++ b/src/main/java/com/dife/api/config/SwaggerConfig.java
@@ -77,7 +77,9 @@ public class SwaggerConfig {
 																															.example(
 																																	new LoginSuccessDto(
 																																			"Given Bearer Token",
-																																			1L)))))))));
+																																			1L,
+																																			Boolean.TRUE,
+																																			"학생증.jpg")))))))));
 		};
 	}
 }

--- a/src/main/java/com/dife/api/controller/MemberController.java
+++ b/src/main/java/com/dife/api/controller/MemberController.java
@@ -106,7 +106,6 @@ public class MemberController {
 			})
 	public ResponseEntity<MemberResponseDto> profile(Authentication auth) {
 		Member currentMember = memberService.getMember(auth.getName());
-		log.info("TokenId : " + currentMember.getTokenId());
 		MemberResponseDto memberResponseDto = new MemberResponseDto(currentMember);
 		return ResponseEntity.ok(memberResponseDto);
 	}

--- a/src/main/java/com/dife/api/jwt/JWTFilter.java
+++ b/src/main/java/com/dife/api/jwt/JWTFilter.java
@@ -11,7 +11,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -68,12 +67,6 @@ public class JWTFilter extends OncePerRequestFilter {
 		String role = e.getClaims().get("role", String.class);
 
 		String newToken = jwtUtil.createAccessJwt(email, role, TOKEN_VALIDITY_DURATION);
-
-		Optional<Member> optionalMember = memberRepository.findByEmail(email);
-
-		Member member = optionalMember.get();
-		member.setTokenId(newToken);
-		memberRepository.save(member);
 
 		response.setHeader(AUTH_HEADER, BEARER_TOKEN_PREFIX + newToken);
 	}

--- a/src/main/java/com/dife/api/jwt/LoginFilter.java
+++ b/src/main/java/com/dife/api/jwt/LoginFilter.java
@@ -79,6 +79,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
 		String email = customUserDetails.getUsername();
 		Long id = customUserDetails.getId();
+		Boolean is_verified = customUserDetails.getIsVerified();
+		String verification_file_id = customUserDetails.getVerificationFileId();
 
 		Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
 		Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
@@ -87,7 +89,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
 		String token = jwtUtil.createAccessJwt(email, role, 60 * 60 * 1000L);
 		ResponseEntity<LoginSuccessDto> responseEntity =
-				ResponseEntity.status(CREATED).body(new LoginSuccessDto(token, id));
+				ResponseEntity.status(CREATED)
+						.body(new LoginSuccessDto(token, id, is_verified, verification_file_id));
 
 		String responseBody = new ObjectMapper().writeValueAsString(responseEntity.getBody());
 		response.getWriter().write(responseBody);

--- a/src/main/java/com/dife/api/jwt/LoginFilter.java
+++ b/src/main/java/com/dife/api/jwt/LoginFilter.java
@@ -40,11 +40,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 		String email = request.getParameter("email");
 		String password = request.getParameter("password");
 
-		log.info("email : " + email);
-		log.info("password : " + password);
 		if (email == null || password == null || email.isEmpty() || password.isEmpty()) {
 			String errorMessage = "이메일과 비밀번호는 필수 사항";
-			log.warn("이메일과 비밀번호는 필수 사항");
 
 			ExceptionResonse exceptionResponse = new ExceptionResonse(false, errorMessage);
 
@@ -102,7 +99,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 			HttpServletRequest request, HttpServletResponse response, AuthenticationException failed)
 			throws IOException {
 
-		log.error("로그인 실패");
 		String errorMessage = "인증에 실패했습니다: " + failed.getMessage();
 
 		ExceptionResonse exceptionResponse = new ExceptionResonse(false, errorMessage);

--- a/src/main/java/com/dife/api/model/dto/CustomUserDetails.java
+++ b/src/main/java/com/dife/api/model/dto/CustomUserDetails.java
@@ -48,6 +48,14 @@ public class CustomUserDetails implements UserDetails {
 		return member.getId();
 	}
 
+	public Boolean getIsVerified() {
+		return member.getIs_verified();
+	}
+
+	public String getVerificationFileId() {
+		return member.getVerification_file_id();
+	}
+
 	@Override
 	public boolean isAccountNonExpired() {
 

--- a/src/main/java/com/dife/api/model/dto/LoginSuccessDto.java
+++ b/src/main/java/com/dife/api/model/dto/LoginSuccessDto.java
@@ -11,4 +11,6 @@ public class LoginSuccessDto {
 
 	private final String accessToken;
 	private final Long member_id;
+	private final Boolean is_verified;
+	private final String verification_file_id;
 }


### PR DESCRIPTION
### 개요
- 온보딩 과정을 고려한 로그인 성공시 is_verified, verification_file_id 보여지게 수정한 PR
- log 삭제
- DB 저장되었던 refreshTokenId 삭제


- 재학생 인증 파일 업로드 하지 않은 상태에서 로그인 
<img width="847" alt="스크린샷 2024-05-15 오전 1 18 30" src="https://github.com/team-diverse/dife-backend/assets/124496650/9725a072-0663-47da-82a2-480b0cc3aead">

- 재학생 인증 파일 업로드 한 상태에서 로그인 
<img width="836" alt="스크린샷 2024-05-15 오전 1 19 15" src="https://github.com/team-diverse/dife-backend/assets/124496650/41e7da7e-9186-4632-965b-f571de72a3dd">


수정사항 없으시면 merge 하겠습니다! :)