### PR TITLE
build(test): testcontainer로 S3, Redis 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testImplementation 'com.h2database:h2'
+	testImplementation 'org.testcontainers:localstack'
+	testImplementation 'org.testcontainers:junit-jupiter'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/src/main/java/com/dife/api/config/AWSConfig.java
+++ b/src/main/java/com/dife/api/config/AWSConfig.java
@@ -11,6 +11,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
+@Profile("!test")
 public class AWSConfig {
 
 	@Value("${spring.aws.access-key}")

--- a/src/main/java/com/dife/api/config/SecurityConfig.java
+++ b/src/main/java/com/dife/api/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.dife.api.jwt.LoginFilter;
 import com.dife.api.repository.MemberRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -17,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@Profile("!test")
 public class SecurityConfig {
 
 	private final AuthenticationConfiguration authenticationConfiguration;

--- a/src/test/java/com/dife/api/config/LocalAWSConfig.java
+++ b/src/test/java/com/dife/api/config/LocalAWSConfig.java
@@ -1,0 +1,31 @@
+package com.dife.api.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@TestConfiguration
+public class LocalAWSConfig {
+	@Bean(initMethod = "start", destroyMethod = "stop")
+	public LocalStackContainer localStackContainer() {
+		return new LocalStackContainer(DockerImageName.parse("localstack/localstack:3"))
+				.withServices(LocalStackContainer.Service.S3);
+	}
+
+	@Bean
+	public S3Client s3Client(LocalStackContainer localStackContainer) {
+		return S3Client.builder()
+				.endpointOverride(localStackContainer.getEndpointOverride(LocalStackContainer.Service.S3))
+				.credentialsProvider(
+						StaticCredentialsProvider.create(
+								AwsBasicCredentials.create(
+										localStackContainer.getAccessKey(), localStackContainer.getSecretKey())))
+				.region(Region.of(localStackContainer.getRegion()))
+				.build();
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,3 +8,9 @@ spring:
     hibernate:
       ddl-auto: create
     show-sql: true
+  main:
+    allow-bean-definition-overriding: true
+  aws:
+    bucket-name: test
+jwt:
+  secret: 001b8ec844c5353413ba8b8c0025c94499eb25ae7486652efb2a89535b2d1a4f


### PR DESCRIPTION
### 개요

- S3와 Redis등 현재 테스트에서 에러가 나고 있다. 이는, 테스트 환경에서 S3와 Redis 인스턴스를 받지 못하는 상황에서 발생하는 것이기에 로컬
테스트에서 이들을 만들어주도록 하는 testcontainer를 사용하자
