### PR TITLE
Feat/chat group enter redis : Redis를 거친 STOMP 입장 메시지 발행

### DIFF
--- a/src/main/java/com/dife/api/config/RedisConfig.java
+++ b/src/main/java/com/dife/api/config/RedisConfig.java
@@ -1,6 +1,7 @@
 package com.dife.api.config;
 
 import com.dife.api.redis.RedisPublisher;
+import com.dife.api.redis.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,8 +10,10 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 @EnableRedisRepositories
 @Configuration
@@ -48,16 +51,16 @@ public class RedisConfig {
 		return new RedisPublisher(redisTemplate(), topic);
 	}
 
-	//	@Bean
-	//	public MessageListenerAdapter messageListener() {
-	//		return new MessageListenerAdapter(new RedisSubscriber());
-	//	}
-	//
+	@Bean
+	public MessageListenerAdapter messageListener(SimpMessagingTemplate messagingTemplate) {
+		return new MessageListenerAdapter(new RedisSubscriber(redisTemplate(), messagingTemplate));
+	}
 
 	@Bean
-	public RedisMessageListenerContainer redisMessageListener() {
+	public RedisMessageListenerContainer redisContainer(SimpMessagingTemplate messagingTemplate) {
 		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
 		container.setConnectionFactory(lettuceConnectionFactory());
+		container.addMessageListener(messageListener(messagingTemplate), topic());
 		return container;
 	}
 }

--- a/src/main/java/com/dife/api/config/RedisConfig.java
+++ b/src/main/java/com/dife/api/config/RedisConfig.java
@@ -1,7 +1,6 @@
 package com.dife.api.config;
 
 import com.dife.api.redis.RedisPublisher;
-import com.dife.api.redis.RedisSubscriber;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,7 +9,6 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -42,7 +40,7 @@ public class RedisConfig {
 
 	@Bean
 	public ChannelTopic topic() {
-		return new ChannelTopic("chat");
+		return new ChannelTopic("chatroom");
 	}
 
 	@Bean
@@ -50,16 +48,16 @@ public class RedisConfig {
 		return new RedisPublisher(redisTemplate(), topic);
 	}
 
-	@Bean
-	public MessageListenerAdapter messageListener() {
-		return new MessageListenerAdapter(new RedisSubscriber());
-	}
+	//	@Bean
+	//	public MessageListenerAdapter messageListener() {
+	//		return new MessageListenerAdapter(new RedisSubscriber());
+	//	}
+	//
 
 	@Bean
-	public RedisMessageListenerContainer redisContainer() {
+	public RedisMessageListenerContainer redisMessageListener() {
 		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
 		container.setConnectionFactory(lettuceConnectionFactory());
-		container.addMessageListener(messageListener(), topic());
 		return container;
 	}
 }

--- a/src/main/java/com/dife/api/config/WebSockConfig.java
+++ b/src/main/java/com/dife/api/config/WebSockConfig.java
@@ -17,7 +17,7 @@ public class WebSockConfig implements WebSocketMessageBrokerConfigurer {
 
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry config) {
-		config.enableSimpleBroker("/topic");
-		config.setApplicationDestinationPrefixes("/app");
+		config.enableSimpleBroker("/sub");
+		config.setApplicationDestinationPrefixes("/pub");
 	}
 }

--- a/src/main/java/com/dife/api/controller/SocketController.java
+++ b/src/main/java/com/dife/api/controller/SocketController.java
@@ -3,12 +3,11 @@ package com.dife.api.controller;
 import com.dife.api.model.dto.ChatDto;
 import com.dife.api.model.dto.ChatEnterDto;
 import com.dife.api.service.ChatService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.handler.annotation.*;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,14 +17,10 @@ public class SocketController {
 
 	private final ChatService chatService;
 
-	@MessageMapping("/chatroom/enter/{id}")
-	@SendTo("/topic/chatroom")
-	public void sendEnter(
-			@DestinationVariable("id") Long id,
-			ChatEnterDto dto,
-			@Header("simpSessionId") String sessionId) {
-
-		chatService.sendEnter(id, dto, sessionId);
+	@MessageMapping("/chatroom/enter")
+	public void sendEnter(ChatEnterDto dto, SimpMessageHeaderAccessor headerAccessor)
+			throws JsonProcessingException {
+		chatService.sendEnter(dto, headerAccessor);
 	}
 
 	@MessageMapping("/chatroom/chat/{id}")

--- a/src/main/java/com/dife/api/redis/RedisPublisher.java
+++ b/src/main/java/com/dife/api/redis/RedisPublisher.java
@@ -1,15 +1,25 @@
 package com.dife.api.redis;
 
+import com.dife.api.model.dto.ChatEnterDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
 
+@Service
 @AllArgsConstructor
+@Slf4j
 public class RedisPublisher {
 	private RedisTemplate<String, String> redisTemplate;
 	private ChannelTopic topic;
 
-	public void publish(String message) {
-		redisTemplate.convertAndSend(topic.getTopic(), message);
+	public void publish(ChatEnterDto dto) throws JsonProcessingException {
+		ObjectMapper mapper = new ObjectMapper();
+		String jsonMessage = mapper.writeValueAsString(dto);
+
+		redisTemplate.convertAndSend(topic.getTopic(), jsonMessage);
 	}
 }

--- a/src/main/java/com/dife/api/redis/RedisSubscriber.java
+++ b/src/main/java/com/dife/api/redis/RedisSubscriber.java
@@ -1,15 +1,36 @@
 package com.dife.api.redis;
 
+import com.dife.api.model.dto.ChatEnterDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
-import org.springframework.stereotype.Component;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
 
 @Slf4j
-@Component
+@Service
+@RequiredArgsConstructor
 public class RedisSubscriber implements MessageListener {
+
+	private final RedisTemplate redisTemplate;
+	private final SimpMessagingTemplate messagingTemplate;
+
 	@Override
 	public void onMessage(Message message, byte[] pattern) {
-		log.info("Message received: " + message.toString());
+		try {
+			byte[] messageBody = message.getBody();
+			String publishMessage = (String) redisTemplate.getStringSerializer().deserialize(messageBody);
+
+			ObjectMapper objectMapper = new ObjectMapper();
+			ChatEnterDto dto = objectMapper.readValue(publishMessage, ChatEnterDto.class);
+
+			messagingTemplate.convertAndSend(
+					"/sub/chatroom/" + dto.getChatroom_id(), dto.getSender() + "님이 입장하셨습니다!");
+		} catch (Exception e) {
+			log.error(e.getMessage());
+		}
 	}
 }

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -14,8 +14,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.listener.ChannelTopic;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -31,10 +29,7 @@ public class ChatService {
 	private final ChatroomService chatroomService;
 	private final ChatroomRepository chatroomRepository;
 	private final ChatRepository chatRepository;
-	private final RedisMessageListenerContainer redisMessageListenerContainer;
-	private final RedisSubscriber redisSubscriber;
 	private final RedisPublisher redisPublisher;
-	private final ChannelTopic topic;
 
 	public void sendMessage(Long room_id, ChatDto dto, String session_id) {
 
@@ -60,7 +55,6 @@ public class ChatService {
 		Long room_id = dto.getChatroom_id();
 
 		String session_id = headerAccessor.getSessionId();
-
 
 		Boolean is_valid = chatroomService.findChatroomById(room_id);
 		if (!is_valid) {

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -90,8 +90,11 @@ public class ChatService {
 			Integer nCount = setting.getCount();
 			nCount++;
 			setting.setCount(nCount);
-			messagingTemplate.convertAndSend(
-					"/topic/chatroom/" + room_id, dto.getSender() + "님이 입장하셨습니다!");
+
+			headerAccessor.getSessionAttributes().put("session_id", session_id);
+			headerAccessor.getSessionAttributes().put("chatroom_id", room_id);
+
+			redisPublisher.publish(dto);
 		}
 		chatroomRepository.save(chatroom);
 	}

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -7,7 +7,6 @@ import com.dife.api.model.ChatroomSetting;
 import com.dife.api.model.dto.ChatDto;
 import com.dife.api.model.dto.ChatEnterDto;
 import com.dife.api.redis.RedisPublisher;
-import com.dife.api.redis.RedisSubscriber;
 import com.dife.api.repository.ChatRepository;
 import com.dife.api.repository.ChatroomRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;


### PR DESCRIPTION
### 개요
- 기존 입장 메시지 발행에 Redis를 거침을 추가
- RedisTemplate을 이용해 Publisher와 Subscriber 간의 상호작용 조절
- RedisSubscriber 수정으로 인한 MessageListenerAdapter 를 주석처리했는데 혹시나 나은 코드가 있다면 알려주시면 감사하겠습니다!

- 입장 테스트 확인 및 APIC 웹소켓 엔드포인트 수정 완료했습니다!
<img width="1082" alt="스크린샷 2024-05-18 오전 12 16 21" src="https://github.com/team-diverse/dife-backend/assets/124496650/8a0a4144-3e69-4254-a04f-2b230577b026">

#### 추후 진행사항
- 채팅, 퇴장 메시지 Redis 적용