### PR TITLE
test(config): @SpringBootTest를 사용하면 에러가 나는 현상 잡기

### DIFF
--- a/src/test/java/com/dife/api/LocalRedisIT.java
+++ b/src/test/java/com/dife/api/LocalRedisIT.java
@@ -1,29 +1,36 @@
 package com.dife.api;
 
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.sync.RedisCommands;
-import org.junit.jupiter.api.Assertions;
+import com.dife.api.config.LocalRedisConfig;
+import com.dife.api.config.TestConfig;
+import com.dife.api.model.ChatType;
+import com.dife.api.model.dto.ChatRequestDto;
+import com.dife.api.redis.RedisPublisher;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.junit.jupiter.Container;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
+@ActiveProfiles("test")
+@SpringBootTest
+@Import(TestConfig.class)
+@ExtendWith(LocalRedisConfig.class)
 @Testcontainers
 public class LocalRedisIT {
-    @Container
-    LocalStackContainer container = new LocalStackContainer(DockerImageName.parse("redis:5.0.3-alpine"));
+
+    @Autowired
+    private RedisPublisher redisPublisher;
 
     @Test
-    void test() {
-        // Test code here
-        String redisURI = container.getRedisURI();
-        RedisClient client = RedisClient.create(redisURI);
-        try (StatefulRedisConnection<String, String> connection = client.connect()) {
-            RedisCommands<String, String> commands = connection.sync();
-            Assertions.assertEquals("PONG", commands.ping());
-        }
+    void test() throws Exception {
+        ChatRequestDto chatRequestDto = new ChatRequestDto();
+        chatRequestDto.setChatroomId(1L);
+        chatRequestDto.setUsername("user1");
+        chatRequestDto.setChatType(ChatType.CHAT);
+        chatRequestDto.setMessage("Hello, Redis!");
 
+        redisPublisher.publish(chatRequestDto);
     }
 }

--- a/src/test/java/com/dife/api/LocalRedisIT.java
+++ b/src/test/java/com/dife/api/LocalRedisIT.java
@@ -20,17 +20,16 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 public class LocalRedisIT {
 
-    @Autowired
-    private RedisPublisher redisPublisher;
+	@Autowired private RedisPublisher redisPublisher;
 
-    @Test
-    void test() throws Exception {
-        ChatRequestDto chatRequestDto = new ChatRequestDto();
-        chatRequestDto.setChatroomId(1L);
-        chatRequestDto.setUsername("user1");
-        chatRequestDto.setChatType(ChatType.CHAT);
-        chatRequestDto.setMessage("Hello, Redis!");
+	@Test
+	void test() throws Exception {
+		ChatRequestDto chatRequestDto = new ChatRequestDto();
+		chatRequestDto.setChatroomId(1L);
+		chatRequestDto.setUsername("user1");
+		chatRequestDto.setChatType(ChatType.CHAT);
+		chatRequestDto.setMessage("Hello, Redis!");
 
-        redisPublisher.publish(chatRequestDto);
-    }
+		redisPublisher.publish(chatRequestDto);
+	}
 }

--- a/src/test/java/com/dife/api/LocalRedisIT.java
+++ b/src/test/java/com/dife/api/LocalRedisIT.java
@@ -1,0 +1,29 @@
+package com.dife.api;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public class LocalRedisIT {
+    @Container
+    LocalStackContainer container = new LocalStackContainer(DockerImageName.parse("redis:5.0.3-alpine"));
+
+    @Test
+    void test() {
+        // Test code here
+        String redisURI = container.getRedisURI();
+        RedisClient client = RedisClient.create(redisURI);
+        try (StatefulRedisConnection<String, String> connection = client.connect()) {
+            RedisCommands<String, String> commands = connection.sync();
+            Assertions.assertEquals("PONG", commands.ping());
+        }
+
+    }
+}

--- a/src/test/java/com/dife/api/LocalS3IT.java
+++ b/src/test/java/com/dife/api/LocalS3IT.java
@@ -1,6 +1,13 @@
 package com.dife.api;
 
+import com.dife.api.config.LocalRedisConfig;
+import com.dife.api.config.TestConfig;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -21,6 +28,10 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SpringBootTest
+@ActiveProfiles("test")
+@Import({TestConfig.class})
+@ExtendWith(LocalRedisConfig.class)
 @Testcontainers
 public class LocalS3IT {
     @Container

--- a/src/test/java/com/dife/api/LocalS3IT.java
+++ b/src/test/java/com/dife/api/LocalS3IT.java
@@ -1,0 +1,55 @@
+package com.dife.api;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+public class LocalS3IT {
+    @Container
+    LocalStackContainer container = new LocalStackContainer(DockerImageName.parse("localstack/localstack"));
+
+    @Test
+    void test() {
+        S3Client s3Client = S3Client.builder()
+                .endpointOverride(container.getEndpointOverride(LocalStackContainer.Service.S3))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(container.getAccessKey(), container.getSecretKey())
+                ))
+                .region(Region.of(container.getRegion()))
+                .build();
+
+        String bucketName = "test-bucket";
+        s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
+
+        String content = "Hello World";
+        String key = "s3-key";
+        s3Client.putObject(PutObjectRequest.builder().bucket(bucketName).key(key).build(),
+                software.amazon.awssdk.core.sync.RequestBody.fromString(content));
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(
+                s3Client.getObject(GetObjectRequest.builder().bucket(bucketName).key(key).build()),
+                StandardCharsets.UTF_8));
+        List<String> results = reader.lines().collect(Collectors.toList());
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0)).isEqualTo(content);
+    }
+}

--- a/src/test/java/com/dife/api/config/LocalAWSConfig.java
+++ b/src/test/java/com/dife/api/config/LocalAWSConfig.java
@@ -2,6 +2,7 @@ package com.dife.api.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -10,6 +11,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @TestConfiguration
+@Profile("test")
 public class LocalAWSConfig {
 	@Bean(initMethod = "start", destroyMethod = "stop")
 	public LocalStackContainer localStackContainer() {

--- a/src/test/java/com/dife/api/config/LocalRedisConfig.java
+++ b/src/test/java/com/dife/api/config/LocalRedisConfig.java
@@ -1,0 +1,13 @@
+package com.dife.api.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+
+@TestConfiguration
+public class LocalRedisConfig {
+	@Bean(initMethod = "start", destroyMethod = "stop")
+	public LocalStackContainer redisContainer() {
+		return new LocalStackContainer("redis:5.0.3-alpine");
+	}
+}

--- a/src/test/java/com/dife/api/config/LocalRedisConfig.java
+++ b/src/test/java/com/dife/api/config/LocalRedisConfig.java
@@ -8,16 +8,13 @@ import org.testcontainers.utility.DockerImageName;
 public class LocalRedisConfig implements BeforeAllCallback {
 	private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
 	private static final int REDIS_PORT = 6379;
-  	private GenericContainer redis;
+	private GenericContainer redis;
 
-  @Override
-  public void beforeAll(ExtensionContext context) {
-    redis = new GenericContainer(DockerImageName.parse(REDIS_IMAGE))
-      .withExposedPorts(REDIS_PORT);
-    redis.start();
-    System.setProperty("spring.data.redis.host", redis.getHost());
-    System.setProperty("spring.data.redis.port", String.valueOf(redis.getMappedPort(REDIS_PORT
-    )));
-  }
-
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		redis = new GenericContainer(DockerImageName.parse(REDIS_IMAGE)).withExposedPorts(REDIS_PORT);
+		redis.start();
+		System.setProperty("spring.data.redis.host", redis.getHost());
+		System.setProperty("spring.data.redis.port", String.valueOf(redis.getMappedPort(REDIS_PORT)));
+	}
 }

--- a/src/test/java/com/dife/api/config/LocalRedisConfig.java
+++ b/src/test/java/com/dife/api/config/LocalRedisConfig.java
@@ -1,13 +1,23 @@
 package com.dife.api.config;
 
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
 
-@TestConfiguration
-public class LocalRedisConfig {
-	@Bean(initMethod = "start", destroyMethod = "stop")
-	public LocalStackContainer redisContainer() {
-		return new LocalStackContainer("redis:5.0.3-alpine");
-	}
+public class LocalRedisConfig implements BeforeAllCallback {
+	private static final String REDIS_IMAGE = "redis:7.0.8-alpine";
+	private static final int REDIS_PORT = 6379;
+  	private GenericContainer redis;
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    redis = new GenericContainer(DockerImageName.parse(REDIS_IMAGE))
+      .withExposedPorts(REDIS_PORT);
+    redis.start();
+    System.setProperty("spring.data.redis.host", redis.getHost());
+    System.setProperty("spring.data.redis.port", String.valueOf(redis.getMappedPort(REDIS_PORT
+    )));
+  }
+
 }

--- a/src/test/java/com/dife/api/config/TestConfig.java
+++ b/src/test/java/com/dife/api/config/TestConfig.java
@@ -1,0 +1,22 @@
+package com.dife.api.config;
+
+import com.dife.api.service.FileService;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import static org.mockito.Mockito.mock;
+
+@TestConfiguration
+public class TestConfig {
+    @Bean
+    public JavaMailSender javaMailSender() {
+        return mock(JavaMailSender.class);
+    }
+
+    @Bean
+    public FileService fileService() {
+        return mock(FileService.class);
+    }
+}

--- a/src/test/java/com/dife/api/config/TestConfig.java
+++ b/src/test/java/com/dife/api/config/TestConfig.java
@@ -1,22 +1,21 @@
 package com.dife.api.config;
 
+import static org.mockito.Mockito.mock;
+
 import com.dife.api.service.FileService;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.mail.javamail.JavaMailSender;
 
-import static org.mockito.Mockito.mock;
-
 @TestConfiguration
 public class TestConfig {
-    @Bean
-    public JavaMailSender javaMailSender() {
-        return mock(JavaMailSender.class);
-    }
+	@Bean
+	public JavaMailSender javaMailSender() {
+		return mock(JavaMailSender.class);
+	}
 
-    @Bean
-    public FileService fileService() {
-        return mock(FileService.class);
-    }
+	@Bean
+	public FileService fileService() {
+		return mock(FileService.class);
+	}
 }


### PR DESCRIPTION
현재 RaceCondition등 여러 테스트에서 @SpringBootTest를 활용해서 context loading이 필요하다.
그런데, 현재 외부 Bean이 테스트에서 적절히 대체되지 않아 에러가 발생한다.

따라서, 임시 방편으로 처리를 해준다.