### PR TITLE
fix(cors): HTTP Request CORS 문제 해결

### DIFF
--- a/src/main/java/com/dife/api/config/WebConfig.java
+++ b/src/main/java/com/dife/api/config/WebConfig.java
@@ -1,0 +1,13 @@
+package com.dife.api.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**").allowedOrigins("http://localhost:8081");
+	}
+}


### PR DESCRIPTION
### 개요 및 수정사항

- 현재, Websocket을 구현하면서 iOS를 터널링을 하지 않는 이상, iOS 개발이 어렵다. 따라서 현재 Web으로 개발을 하고 있는데, 이를 위해 localhost:8081 CORS를 허용해준다. (브라우저에서 테스트하기 때문에 필요하다)

(이후에 필요에 따라 CORS 엔드포인트 허용 env 변수로 뺄 예정 -> 아직은 Web버전 지원을 하지 않기 때문에 8081로 남겨두고자함)