### PR TITLE
Feat/file get

### DIFF
--- a/src/main/java/com/dife/api/config/AWSConfig.java
+++ b/src/main/java/com/dife/api/config/AWSConfig.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @Profile("!test")
@@ -43,6 +44,16 @@ public class AWSConfig {
 		return S3Client.builder()
 				.credentialsProvider(
 						StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+				.region(Region.of(awsRegion))
+				.build();
+	}
+
+	@Bean
+	public S3Presigner presigner() {
+		return S3Presigner.builder()
+				.credentialsProvider(
+						StaticCredentialsProvider.create(
+								AwsSessionCredentials.create(accessKey, secretKey, sessionToken)))
 				.region(Region.of(awsRegion))
 				.build();
 	}

--- a/src/main/java/com/dife/api/model/File.java
+++ b/src/main/java/com/dife/api/model/File.java
@@ -21,6 +21,9 @@ public class File {
 	private Long id;
 
 	@Column(nullable = false)
+	private String originalName;
+
+	@Column(nullable = false)
 	private String name;
 
 	@Column(nullable = false)

--- a/src/main/java/com/dife/api/model/dto/FileDto.java
+++ b/src/main/java/com/dife/api/model/dto/FileDto.java
@@ -15,6 +15,8 @@ import lombok.Setter;
 public class FileDto {
 	private Long id;
 
+	@NotNull private String originalName;
+
 	@NotNull private String name;
 
 	@NotNull private String size;

--- a/src/main/java/com/dife/api/model/dto/MemberResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/MemberResponseDto.java
@@ -46,10 +46,11 @@ public class MemberResponseDto {
 	@Schema(description = "취미", example = "Soccer")
 	private Set<String> hobbies;
 
-	@Schema(
-			description = "프로필 파일 접근 가능한 S3경로",
-			example = "https://dife-bucket.s3.amazonaws.com/cookie.jpeg")
+	@Schema(description = "S3에 저장되는 프로필 이미지", example = "cookie.jpeg")
 	private String profileFileName;
+
+	@Schema(description = "Presigned S3경로")
+	private String profilePresignUrl;
 
 	@Schema(description = "한줄 소개", example = "hello")
 	private String bio;

--- a/src/main/java/com/dife/api/model/dto/MemberResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/MemberResponseDto.java
@@ -46,7 +46,9 @@ public class MemberResponseDto {
 	@Schema(description = "취미", example = "Soccer")
 	private Set<String> hobbies;
 
-	@Schema(description = "프로필 파일 이름", example = "cookie.jpeg")
+	@Schema(
+			description = "프로필 파일 접근 가능한 S3경로",
+			example = "https://dife-bucket.s3.amazonaws.com/cookie.jpeg")
 	private String profileFileName;
 
 	@Schema(description = "한줄 소개", example = "hello")

--- a/src/main/java/com/dife/api/service/FileService.java
+++ b/src/main/java/com/dife/api/service/FileService.java
@@ -49,6 +49,7 @@ public class FileService {
 		}
 
 		File fileInfo = new File();
+		fileInfo.setOriginalName(originalFilename);
 		fileInfo.setName(fileName);
 		fileInfo.setSize(fileSize);
 		fileInfo.setUrl("https://");

--- a/src/main/java/com/dife/api/service/FileService.java
+++ b/src/main/java/com/dife/api/service/FileService.java
@@ -58,4 +58,8 @@ public class FileService {
 
 		return modelMapper.map(fileInfo, FileDto.class);
 	}
+
+	public String getImageUrl(String fileName) {
+		return String.format("https://%s.s3.amazonaws.com/%s", bucketName, fileName);
+	}
 }

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -96,8 +96,7 @@ public class MemberService {
 			member.setProfileFileName("empty");
 		else {
 			FileDto profileImgPath = fileService.upload(profileImg);
-			String imageUrl = fileService.getImageUrl(profileImgPath.getOriginalName());
-			member.setProfileFileName(imageUrl);
+			member.setProfileFileName(profileImgPath.getOriginalName());
 		}
 
 		if (verificationFile == null
@@ -172,8 +171,10 @@ public class MemberService {
 	public MemberResponseDto getMember(String email) {
 
 		Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+		MemberResponseDto responseDto = memberModelMapper.map(member, MemberResponseDto.class);
 
-		return memberModelMapper.map(member, MemberResponseDto.class);
+		responseDto.setProfilePresignUrl(fileService.getPresignUrl(member.getProfileFileName()));
+		return responseDto;
 	}
 
 	public void changePassword(String email) {

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -96,7 +96,8 @@ public class MemberService {
 			member.setProfileFileName("empty");
 		else {
 			FileDto profileImgPath = fileService.upload(profileImg);
-			member.setProfileFileName(profileImgPath.getName());
+			String imageUrl = fileService.getImageUrl(profileImgPath.getOriginalName());
+			member.setProfileFileName(imageUrl);
 		}
 
 		if (verificationFile == null
@@ -117,20 +118,25 @@ public class MemberService {
 			if (!hobbyRepository.existsHobbyByNameAndMember(hobbyName, member)) {
 				Hobby nHobby = new Hobby();
 				nHobby.setName(hobbyName);
+				nHobby.setMember(member);
 				hobbyRepository.save(nHobby);
 				myHobbies.add(nHobby);
 			}
 		}
+		member.setHobbies(myHobbies);
 
 		Set<Language> myLanguages = member.getLanguages();
 		for (String languageName : languages) {
 			if (!languageRepository.existsLanguageByNameAndMember(languageName, member)) {
 				Language nLanguage = new Language();
 				nLanguage.setName(languageName);
+				nLanguage.setMember(member);
 				languageRepository.save(nLanguage);
 				myLanguages.add(nLanguage);
 			}
 		}
+
+		member.setLanguages(myLanguages);
 
 		member.setIsPublic(isPublic);
 		memberRepository.save(member);


### PR DESCRIPTION
#### 개요 
- S3로 업로드 한 프로필 이미지 URL 접근가능하도록 구성한 PR입니다!
- 기존 회원가입 2시 언어, 취미 설정 시에 profile에 나타나지 않았던 오류 발견 및 해결


#### 시나리오
1. 회원가입1 -> 로그인 -> 회원가입2 하면 fileName에 원본 프로필 이미지가 들어옴을 확인할 수 있음
```
"profileFileName": "cookie.jpeg",
"profilePresignUrl": null,
```
2. "/profile" 접근 시에 ResponseBody에 PresignURL이 채워짐을 확인할 수 있음
```
"profileFileName": "cookie.jpeg",
"profilePresignUrl": "https://dife-bucket.s3.ap-northeast-2.amazonaws.com/cookie.jpeg?X-Amz-Security-Token=IQoJb3JpZ2luX2VjEGMaDmFwLW5vcnRoZWFzdC0yIkcwRQIhAKYRSwlsd5%2FANQRBUcjmKmcGsyuCZtQmkLgsYVz6tGr%2FAiBhKCeV7PdvQkejwu%2B%2B%2BzpJieIGHzeMt4G0NVBL3wBmjSr4AQjs%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAAaDDU5MDE4NDEzNzY2NCIMIaTkLo4TUiU9da%2B1KswBTlndmnW%2BzG%2BpxIA9OpEqbX73nOOR75UuKcP9nyn389vSf49wg4mXZ0d3Bto2eMWO5teoSxRGfii4fsc6Qvq3I1%2BG7b%2BXXEAAHL9rgbcSv%2FTgsae5GToLHTMqKtUH1r7ucofdpqb%2BXzDDO%2BT%2FpARri3YFQF9fKeDDLUrwgRaNSJU5MyDBYXVOlYxXq5OkR1KCwEOFuZhBZtMmCR0SMU3DQeRLKc7o7p3VE3EelEnXrzryQYfYZwB8rTsYKZRvF81laKswGO5sYAmEBjx0MNnRi7MGOpgBZWyvd%2Fcg5SIndtSYjPY7JwLi5pMGgRFV4wJaAKr1RXJyaSyQCWsk8UGg7tSMj16s7p%2FkdUbudmhTL%2FYfpv4dWfa6O9tVekTMKk1oDQuTH1ot%2BruAwz4c2h0%2FZWNw24ec3EiVoxwH8Wfvb4xFLip3xKF%2FII7zjVAbdqfQx%2FwLPGX3IekjXTaCy0z5Zp%2Bz%2BSHo5PXGkI93ygs%3D&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20240607T114345Z&X-Amz-SignedHeaders=host&X-Amz-Expires=300&X-Amz-Credential=ASIAYS2NXIPACGW7XBWJ%2F20240607%2Fap-northeast-2%2Fs3%2Faws4_request&X-Amz-Signature=1fa728b6d987cdea2688568d560982caafcd69c8454dd58385cb907eac18b592",
```
3. 해당 URL을 접근했을 때 파일이 다운되는 것을 확인할 수 있음