### PR TITLE
refactor/chat-add-dto: 채팅에서 필요한 정보 추가

### DIFF
--- a/src/main/java/com/dife/api/model/Chat.java
+++ b/src/main/java/com/dife/api/model/Chat.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,4 +30,8 @@ public class Chat {
 	@JoinColumn(name = "chatroom_id")
 	@JsonIgnore
 	private Chatroom chatroom;
+
+	private String username;
+
+	private LocalDateTime created;
 }

--- a/src/main/java/com/dife/api/model/Member.java
+++ b/src/main/java/com/dife/api/model/Member.java
@@ -66,9 +66,9 @@ public class Member extends BaseTimeEntity {
 	@OneToMany(mappedBy = "toMember")
 	private Set<Connect> received;
 
-	@ManyToMany(mappedBy = "members", fetch = FetchType.LAZY)
+	@ManyToMany(mappedBy = "members")
 	@JsonBackReference
-	private Set<Chatroom> chatrooms;
+	private Set<Chatroom> chatrooms = new HashSet<>();
 
 	@OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
 	@JsonIgnore

--- a/src/main/java/com/dife/api/model/dto/ChatRequestDto.java
+++ b/src/main/java/com/dife/api/model/dto/ChatRequestDto.java
@@ -2,6 +2,7 @@ package com.dife.api.model.dto;
 
 import com.dife.api.model.ChatType;
 import com.dife.api.model.ChatroomType;
+import java.time.LocalDateTime;
 import lombok.*;
 
 @Getter
@@ -17,4 +18,5 @@ public class ChatRequestDto {
 	private Long chatroomId;
 	private Long memberId;
 	private String username;
+	private LocalDateTime created;
 }

--- a/src/main/java/com/dife/api/model/dto/ChatResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/ChatResponseDto.java
@@ -2,6 +2,7 @@ package com.dife.api.model.dto;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import lombok.*;
 
 @Getter
@@ -16,4 +17,8 @@ public class ChatResponseDto {
 	@NotNull
 	@Size(max = 300)
 	private String message;
+
+	private LocalDateTime created;
+
+	private String username;
 }

--- a/src/main/java/com/dife/api/redis/RedisPublisher.java
+++ b/src/main/java/com/dife/api/redis/RedisPublisher.java
@@ -3,6 +3,7 @@ package com.dife.api.redis;
 import com.dife.api.model.dto.ChatRequestDto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -18,6 +19,7 @@ public class RedisPublisher {
 
 	public void publish(ChatRequestDto dto) throws JsonProcessingException {
 		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
 		String jsonMessage = mapper.writeValueAsString(dto);
 
 		redisTemplate.convertAndSend(topic.getTopic(), jsonMessage);

--- a/src/main/java/com/dife/api/redis/RedisSubscriber.java
+++ b/src/main/java/com/dife/api/redis/RedisSubscriber.java
@@ -2,7 +2,7 @@ package com.dife.api.redis;
 
 import com.dife.api.model.dto.ChatRequestDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDateTime;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -28,13 +28,14 @@ public class RedisSubscriber implements MessageListener {
 			String publishMessage = (String) redisTemplate.getStringSerializer().deserialize(messageBody);
 
 			ObjectMapper objectMapper = new ObjectMapper();
+			objectMapper.registerModule(new JavaTimeModule());
 			ChatRequestDto dto = objectMapper.readValue(publishMessage, ChatRequestDto.class);
 			String destination = "/sub/chatroom/" + dto.getChatroomId();
 
 			Map<String, Object> enterMessage = new HashMap<>();
 			enterMessage.put("username", dto.getUsername());
 			enterMessage.put("message", dto.getMessage());
-			enterMessage.put("created", LocalDateTime.now());
+			enterMessage.put("created", dto.getCreated());
 			messagingTemplate.convertAndSend(destination, enterMessage);
 		} catch (Exception e) {
 			log.error(e.getMessage());

--- a/src/main/java/com/dife/api/redis/RedisSubscriber.java
+++ b/src/main/java/com/dife/api/redis/RedisSubscriber.java
@@ -31,25 +31,11 @@ public class RedisSubscriber implements MessageListener {
 			ChatRequestDto dto = objectMapper.readValue(publishMessage, ChatRequestDto.class);
 			String destination = "/sub/chatroom/" + dto.getChatroomId();
 
-			switch (dto.getChatType()) {
-				case ENTER:
-					Map<String, Object> enterMessage = new HashMap<>();
-					enterMessage.put("message", dto.getUsername() + "님이 입장하셨습니다!");
-					messagingTemplate.convertAndSend(destination, enterMessage);
-					break;
-				case CHAT:
-					Map<String, Object> chatMessage = new HashMap<>();
-					chatMessage.put("username", dto.getUsername());
-					chatMessage.put("message", dto.getMessage());
-					chatMessage.put("created", LocalDateTime.now());
-					messagingTemplate.convertAndSend(destination, chatMessage);
-					break;
-				case EXIT:
-					Map<String, Object> exitMessage = new HashMap<>();
-					exitMessage.put("message", dto.getUsername() + "님이 퇴장하셨습니다!");
-					messagingTemplate.convertAndSend(destination, exitMessage);
-					break;
-			}
+			Map<String, Object> enterMessage = new HashMap<>();
+			enterMessage.put("username", dto.getUsername());
+			enterMessage.put("message", dto.getMessage());
+			enterMessage.put("created", LocalDateTime.now());
+			messagingTemplate.convertAndSend(destination, enterMessage);
 		} catch (Exception e) {
 			log.error(e.getMessage());
 		}

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -11,6 +11,7 @@ import com.dife.api.repository.ChatRepository;
 import com.dife.api.repository.ChatroomRepository;
 import com.dife.api.repository.MemberRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
@@ -89,6 +90,8 @@ public class ChatService {
 			Chat chat = new Chat();
 			chat.setMessage(dto.getMessage());
 			chat.setChatroom(chatroom);
+			chat.setUsername(username);
+			chat.setCreated(LocalDateTime.now());
 
 			chatroom.getChats().add(chat);
 			chatRepository.save(chat);


### PR DESCRIPTION
#### 개요
- 채팅에 회원의 닉네임과 보낸시각 표시하는 PR입니다!
- Chat, ChatRequestDto, ChatService, ChatResponseDto:
- 채팅에 보낸 시간, 보낸이의 별명 추가
- RedisSubscriber:
- 저장되는 채팅에만 created 표시되도록 이때, 채팅이 생성되는 시간을 가져올 경우 직렬화 오류 발생 -> LocalDateTime의 경우 그 차이가 00:00:00.00:00:20 차이이기 떄문에 독립적으로 LocalDateTime 설정
- Member:
- 회원이 가진 채팅방 Set 불러오기 가능하도록


#### Apic 테스트 화면
<img width="445" alt="스크린샷 2024-06-14 오전 9 36 50" src="https://github.com/team-diverse/dife-backend/assets/124496650/eeef7b9c-c807-48eb-819a-ab248f93d5d4">
