### PR TITLE
Feat/like post : 게시글 좋아요 구현

### DIFF
--- a/src/main/java/com/dife/api/controller/LikeController.java
+++ b/src/main/java/com/dife/api/controller/LikeController.java
@@ -3,7 +3,9 @@ package com.dife.api.controller;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.dife.api.model.dto.LikeCreateRequestDto;
+import com.dife.api.model.dto.PostResponseDto;
 import com.dife.api.service.LikeService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -15,6 +17,12 @@ import org.springframework.web.bind.annotation.*;
 public class LikeController {
 
 	private final LikeService likeService;
+
+	@GetMapping
+	public ResponseEntity<List<PostResponseDto>> getLikedPosts(Authentication auth) {
+		List<PostResponseDto> responseDto = likeService.getLikedPosts(auth.getName());
+		return ResponseEntity.status(OK).body(responseDto);
+	}
 
 	@PostMapping
 	public ResponseEntity<Void> createLike(

--- a/src/main/java/com/dife/api/controller/LikeController.java
+++ b/src/main/java/com/dife/api/controller/LikeController.java
@@ -31,4 +31,11 @@ public class LikeController {
 		likeService.createLike(requestDto, auth.getName());
 		return new ResponseEntity<>(OK);
 	}
+
+	@DeleteMapping
+	public ResponseEntity<Void> deleteLikePost(
+			@RequestParam(name = "postId", required = false) Long postId, Authentication auth) {
+		likeService.deleteLikePost(postId, auth.getName());
+		return new ResponseEntity<>(OK);
+	}
 }

--- a/src/main/java/com/dife/api/controller/LikeController.java
+++ b/src/main/java/com/dife/api/controller/LikeController.java
@@ -1,0 +1,26 @@
+package com.dife.api.controller;
+
+import static org.springframework.http.HttpStatus.OK;
+
+import com.dife.api.model.dto.LikeCreateRequestDto;
+import com.dife.api.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/likes")
+public class LikeController {
+
+	private final LikeService likeService;
+
+	@PostMapping
+	public ResponseEntity<Void> createLike(
+			@RequestBody LikeCreateRequestDto requestDto, Authentication auth) {
+
+		likeService.createLike(requestDto, auth.getName());
+		return new ResponseEntity<>(OK);
+	}
+}

--- a/src/main/java/com/dife/api/controller/PostController.java
+++ b/src/main/java/com/dife/api/controller/PostController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/posts")
-public class BoardController implements SwaggerBoardController {
+public class PostController implements SwaggerPostController {
 
 	private final PostService postService;
 

--- a/src/main/java/com/dife/api/controller/SwaggerPostController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerPostController.java
@@ -13,7 +13,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Board API", description = "게시판 서비스 API")
-public interface SwaggerBoardController {
+public interface SwaggerPostController {
 
 	@Operation(summary = "게시판 조회 API", description = "게시판 종류를 입력해 최신순으로 게시판을 조회합니다.")
 	@ApiResponse(responseCode = "200")

--- a/src/main/java/com/dife/api/exception/DuplicateLikeException.java
+++ b/src/main/java/com/dife/api/exception/DuplicateLikeException.java
@@ -1,0 +1,8 @@
+package com.dife.api.exception;
+
+public class DuplicateLikeException extends DuplicateException {
+
+	public DuplicateLikeException() {
+		super("이미 좋아요를 눌렀습니다!");
+	}
+}

--- a/src/main/java/com/dife/api/exception/LikeNotFoundException.java
+++ b/src/main/java/com/dife/api/exception/LikeNotFoundException.java
@@ -1,0 +1,7 @@
+package com.dife.api.exception;
+
+public class LikeNotFoundException extends IllegalStateException {
+	public LikeNotFoundException() {
+		super("해당 좋아요는 존재하지 않습니다.");
+	}
+}

--- a/src/main/java/com/dife/api/model/LikePost.java
+++ b/src/main/java/com/dife/api/model/LikePost.java
@@ -1,0 +1,24 @@
+package com.dife.api.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "post_likes")
+public class LikePost extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "post_id")
+	private Post post;
+
+	@ManyToOne
+	@JoinColumn(name = "member_id")
+	private Member member;
+}

--- a/src/main/java/com/dife/api/model/LikeType.java
+++ b/src/main/java/com/dife/api/model/LikeType.java
@@ -1,6 +1,6 @@
 package com.dife.api.model;
 
 public enum LikeType {
-	POSTLIKES,
-	COMMENTLIKES
+	POST,
+	COMMENT
 }

--- a/src/main/java/com/dife/api/model/LikeType.java
+++ b/src/main/java/com/dife/api/model/LikeType.java
@@ -1,0 +1,6 @@
+package com.dife.api.model;
+
+public enum LikeType {
+	POSTLIKES,
+	COMMENTLIKES
+}

--- a/src/main/java/com/dife/api/model/Member.java
+++ b/src/main/java/com/dife/api/model/Member.java
@@ -81,5 +81,5 @@ public class Member extends BaseTimeEntity {
 
 	@OneToMany(mappedBy = "member", fetch = FetchType.EAGER)
 	@JsonIgnore
-	private List<LikePost> PostLikes;
+	private List<PostLike> PostLikes;
 }

--- a/src/main/java/com/dife/api/model/Member.java
+++ b/src/main/java/com/dife/api/model/Member.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
@@ -77,4 +78,8 @@ public class Member extends BaseTimeEntity {
 	@JsonIgnore
 	@OneToMany(mappedBy = "member")
 	private Set<Post> posts;
+
+	@OneToMany(mappedBy = "member", fetch = FetchType.EAGER)
+	@JsonIgnore
+	private List<LikePost> PostLikes;
 }

--- a/src/main/java/com/dife/api/model/Post.java
+++ b/src/main/java/com/dife/api/model/Post.java
@@ -24,8 +24,6 @@ public class Post extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private BoardCategory boardType = BoardCategory.FREE;
 
-	private Integer likeCount = 0;
-
 	private Integer viewCount = 0;
 
 	@ManyToOne
@@ -34,4 +32,7 @@ public class Post extends BaseTimeEntity {
 
 	@OneToMany(mappedBy = "post", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
 	private List<Comment> comments;
+
+	@OneToMany(mappedBy = "post", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+	private List<LikePost> PostLikes;
 }

--- a/src/main/java/com/dife/api/model/Post.java
+++ b/src/main/java/com/dife/api/model/Post.java
@@ -34,5 +34,5 @@ public class Post extends BaseTimeEntity {
 	private List<Comment> comments;
 
 	@OneToMany(mappedBy = "post", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
-	private List<LikePost> PostLikes;
+	private List<PostLike> PostLikes;
 }

--- a/src/main/java/com/dife/api/model/PostLike.java
+++ b/src/main/java/com/dife/api/model/PostLike.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "post_likes")
-public class LikePost extends BaseTimeEntity {
+public class PostLike extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/dife/api/model/dto/LikeCreateRequestDto.java
+++ b/src/main/java/com/dife/api/model/dto/LikeCreateRequestDto.java
@@ -1,0 +1,18 @@
+package com.dife.api.model.dto;
+
+import com.dife.api.model.LikeType;
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+public class LikeCreateRequestDto {
+
+	private LikeType likeType;
+
+	private Long postId;
+
+	private Long commentId;
+}

--- a/src/main/java/com/dife/api/model/dto/LikeCreateRequestDto.java
+++ b/src/main/java/com/dife/api/model/dto/LikeCreateRequestDto.java
@@ -10,7 +10,7 @@ import lombok.*;
 @NoArgsConstructor
 public class LikeCreateRequestDto {
 
-	private LikeType likeType;
+	private LikeType type;
 
 	private Long postId;
 

--- a/src/main/java/com/dife/api/model/dto/PostResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/PostResponseDto.java
@@ -24,7 +24,7 @@ public class PostResponseDto {
 
 	private Boolean isPublic;
 
-	private Integer likeCount;
+	private Integer likesCount;
 
 	private Integer viewCount;
 

--- a/src/main/java/com/dife/api/repository/LikePostRepository.java
+++ b/src/main/java/com/dife/api/repository/LikePostRepository.java
@@ -1,19 +1,19 @@
 package com.dife.api.repository;
 
-import com.dife.api.model.LikePost;
 import com.dife.api.model.Member;
 import com.dife.api.model.Post;
+import com.dife.api.model.PostLike;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface LikePostRepository extends JpaRepository<LikePost, Long> {
+public interface LikePostRepository extends JpaRepository<PostLike, Long> {
 
-	List<LikePost> findLikePostsByMember(Member member);
+	List<PostLike> findPostLikesByMember(Member member);
 
-	Optional<LikePost> findByPostAndMember(Post post, Member member);
+	Optional<PostLike> findByPostAndMember(Post post, Member member);
 
 	boolean existsByPostAndMember(Post post, Member member);
 }

--- a/src/main/java/com/dife/api/repository/LikePostRepository.java
+++ b/src/main/java/com/dife/api/repository/LikePostRepository.java
@@ -1,0 +1,16 @@
+package com.dife.api.repository;
+
+import com.dife.api.model.LikePost;
+import com.dife.api.model.Member;
+import com.dife.api.model.Post;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LikePostRepository extends JpaRepository<LikePost, Long> {
+
+	Optional<LikePost> findByPostAndMember(Post post, Member member);
+
+	boolean existsByPostAndMember(Post post, Member member);
+}

--- a/src/main/java/com/dife/api/repository/LikePostRepository.java
+++ b/src/main/java/com/dife/api/repository/LikePostRepository.java
@@ -3,12 +3,15 @@ package com.dife.api.repository;
 import com.dife.api.model.LikePost;
 import com.dife.api.model.Member;
 import com.dife.api.model.Post;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LikePostRepository extends JpaRepository<LikePost, Long> {
+
+	List<LikePost> findLikePostsByMember(Member member);
 
 	Optional<LikePost> findByPostAndMember(Post post, Member member);
 

--- a/src/main/java/com/dife/api/service/LikeService.java
+++ b/src/main/java/com/dife/api/service/LikeService.java
@@ -1,0 +1,48 @@
+package com.dife.api.service;
+
+import com.dife.api.exception.DuplicateLikeException;
+import com.dife.api.exception.MemberNotFoundException;
+import com.dife.api.exception.PostNotFoundException;
+import com.dife.api.model.*;
+import com.dife.api.model.dto.LikeCreateRequestDto;
+import com.dife.api.repository.LikePostRepository;
+import com.dife.api.repository.MemberRepository;
+import com.dife.api.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class LikeService {
+
+	private final PostRepository postRepository;
+	private final MemberRepository memberRepository;
+	private final LikePostRepository likePostRepository;
+
+	public void createLike(LikeCreateRequestDto dto, String memberEmail) {
+		switch (dto.getLikeType()) {
+			case POSTLIKES:
+				createLikePost(dto.getPostId(), memberEmail);
+				break;
+			case COMMENTLIKES:
+		}
+	}
+
+	public void createLikePost(Long postId, String memberEmail) {
+		Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
+
+		if (likePostRepository.existsByPostAndMember(post, member)) {
+			throw new DuplicateLikeException();
+		}
+		LikePost likePost = new LikePost();
+		likePost.setPost(post);
+		likePost.setMember(member);
+		likePostRepository.save(likePost);
+	}
+}

--- a/src/main/java/com/dife/api/service/LikeService.java
+++ b/src/main/java/com/dife/api/service/LikeService.java
@@ -36,20 +36,20 @@ public class LikeService {
 		Member member =
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 
-		List<LikePost> likePosts = likePostRepository.findLikePostsByMember(member);
+		List<PostLike> postLikes = likePostRepository.findPostLikesByMember(member);
 
 		List<Post> posts =
-				likePosts.stream().map(LikePost::getPost).distinct().collect(Collectors.toList());
+				postLikes.stream().map(PostLike::getPost).distinct().collect(Collectors.toList());
 
 		return posts.stream().map(b -> modelMapper.map(b, PostResponseDto.class)).collect(toList());
 	}
 
 	public void createLike(LikeCreateRequestDto dto, String memberEmail) {
-		switch (dto.getLikeType()) {
-			case POSTLIKES:
+		switch (dto.getType()) {
+			case POST:
 				createLikePost(dto.getPostId(), memberEmail);
 				break;
-			case COMMENTLIKES:
+			case COMMENT:
 		}
 	}
 
@@ -61,10 +61,10 @@ public class LikeService {
 		if (likePostRepository.existsByPostAndMember(post, member)) {
 			throw new DuplicateLikeException();
 		}
-		LikePost likePost = new LikePost();
-		likePost.setPost(post);
-		likePost.setMember(member);
-		likePostRepository.save(likePost);
+		PostLike postLike = new PostLike();
+		postLike.setPost(post);
+		postLike.setMember(member);
+		likePostRepository.save(postLike);
 	}
 
 	public void deleteLikePost(Long postId, String memberEmail) {
@@ -72,13 +72,13 @@ public class LikeService {
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 		Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
 
-		LikePost likePost =
+		PostLike postLike =
 				likePostRepository
 						.findByPostAndMember(post, member)
 						.orElseThrow(LikeNotFoundException::new);
 
-		likePost.getPost().getPostLikes().remove(likePost);
-		member.getPostLikes().remove(likePost);
-		likePostRepository.delete(likePost);
+		postLike.getPost().getPostLikes().remove(postLike);
+		member.getPostLikes().remove(postLike);
+		likePostRepository.delete(postLike);
 	}
 }

--- a/src/main/java/com/dife/api/service/LikeService.java
+++ b/src/main/java/com/dife/api/service/LikeService.java
@@ -3,6 +3,7 @@ package com.dife.api.service;
 import static java.util.stream.Collectors.toList;
 
 import com.dife.api.exception.DuplicateLikeException;
+import com.dife.api.exception.LikeNotFoundException;
 import com.dife.api.exception.MemberNotFoundException;
 import com.dife.api.exception.PostNotFoundException;
 import com.dife.api.model.*;
@@ -64,5 +65,20 @@ public class LikeService {
 		likePost.setPost(post);
 		likePost.setMember(member);
 		likePostRepository.save(likePost);
+	}
+
+	public void deleteLikePost(Long postId, String memberEmail) {
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
+		Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+
+		LikePost likePost =
+				likePostRepository
+						.findByPostAndMember(post, member)
+						.orElseThrow(LikeNotFoundException::new);
+
+		likePost.getPost().getPostLikes().remove(likePost);
+		member.getPostLikes().remove(likePost);
+		likePostRepository.delete(likePost);
 	}
 }

--- a/src/main/java/com/dife/api/service/LikeService.java
+++ b/src/main/java/com/dife/api/service/LikeService.java
@@ -1,15 +1,21 @@
 package com.dife.api.service;
 
+import static java.util.stream.Collectors.toList;
+
 import com.dife.api.exception.DuplicateLikeException;
 import com.dife.api.exception.MemberNotFoundException;
 import com.dife.api.exception.PostNotFoundException;
 import com.dife.api.model.*;
 import com.dife.api.model.dto.LikeCreateRequestDto;
+import com.dife.api.model.dto.PostResponseDto;
 import com.dife.api.repository.LikePostRepository;
 import com.dife.api.repository.MemberRepository;
 import com.dife.api.repository.PostRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +28,20 @@ public class LikeService {
 	private final PostRepository postRepository;
 	private final MemberRepository memberRepository;
 	private final LikePostRepository likePostRepository;
+
+	private final ModelMapper modelMapper;
+
+	public List<PostResponseDto> getLikedPosts(String memberEmail) {
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
+
+		List<LikePost> likePosts = likePostRepository.findLikePostsByMember(member);
+
+		List<Post> posts =
+				likePosts.stream().map(LikePost::getPost).distinct().collect(Collectors.toList());
+
+		return posts.stream().map(b -> modelMapper.map(b, PostResponseDto.class)).collect(toList());
+	}
 
 	public void createLike(LikeCreateRequestDto dto, String memberEmail) {
 		switch (dto.getLikeType()) {

--- a/src/main/java/com/dife/api/service/PostService.java
+++ b/src/main/java/com/dife/api/service/PostService.java
@@ -56,8 +56,10 @@ public class PostService {
 	@Transactional(readOnly = true)
 	public PostResponseDto getPost(Long id) {
 		Post post = postRepository.findById(id).orElseThrow(PostNotFoundException::new);
+		PostResponseDto responseDto = modelMapper.map(post, PostResponseDto.class);
+		responseDto.setLikesCount(post.getPostLikes().size());
 
-		return modelMapper.map(post, PostResponseDto.class);
+		return responseDto;
 	}
 
 	public PostResponseDto updatePost(Long id, PostUpdateRequestDto dto, String memberEmail) {


### PR DESCRIPTION
#### 개요
- 게시글에 좋아요를 구현한 PR입니다!

> 게시글 좋아요와 게시글 : 다대일 관계
> 게시글 좋아요와 회원 : 다대일 관계
> 좋아요 누르기는 POST, 좋아요 누르기 취소는 DELETE
> 좋아요 누르기 취소 구현시 양방향 관계로 인한 remove를 모두 진행해줌 

- 게시글 좋아요 엔티티를 생성해 구현하였으며 세부 사항은 커밋별로 확인 부탁드립니다!
- 좋아요의 갯수는 엔티티에 필드로 반영되는 것이 아닌 GET할 때 List의 Size로 DTO에 반영되는 것입니다.
- 같은 로직으로 댓글 좋아요 엔티티를 구현하되 좋아요한 댓글을 불러오는 기능은 넣지 않을 예정입니다.

#### 게시글 조회 시 Response Body
```
{
    "id": 1,
    "title": "title1",
    "content": "내용",
    "boardType": "TIP",
    "isPublic": true,
    "likesCount": 1,
    "viewCount": 0,
    ...
}
```

#### 최초 좋아요 시 Response Code
200 OK
#### 좋아요 취소 시 Response Code
409 Conflict

#### 회원 or 게시글 존재하지 않을 시 Response Code
401 UnAuthorized

#### 추후 진행 사항
- 댓글 좋아요 구현