### PR TITLE
Refactor/tags : 태그 목록 로직 수정 및 채팅방에 프로필 이미지 업로드 추가

### DIFF
--- a/src/main/java/com/dife/api/controller/ChatroomController.java
+++ b/src/main/java/com/dife/api/controller/ChatroomController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Controller
 @RequiredArgsConstructor
@@ -35,12 +36,18 @@ public class ChatroomController implements SwaggerChatroomController {
 		return ResponseEntity.status(HttpStatus.OK).body(responseDto);
 	}
 
-	@PostMapping(value = "/", consumes = "application/json")
+	@PostMapping
 	public ResponseEntity<ChatroomResponseDto> createChatroom(
-			@RequestBody ChatroomPostRequestDto requestDto, Authentication authentication) {
+			@RequestParam(name = "profileImg", required = false) MultipartFile profileImg,
+			@RequestParam(name = "chatroomType") ChatroomType chatroomType,
+			@RequestParam(name = "name", required = false) String name,
+			@RequestParam(name = "description", required = false) String description,
+			@RequestParam(name = "toMemberId", required = false) Long toMemberId,
+			Authentication authentication) {
 
 		ChatroomResponseDto responseDto =
-				chatroomService.createChatroom(requestDto, authentication.getName());
+				chatroomService.createChatroom(
+						profileImg, chatroomType, name, description, toMemberId, authentication.getName());
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
 	}

--- a/src/main/java/com/dife/api/controller/ChatroomController.java
+++ b/src/main/java/com/dife/api/controller/ChatroomController.java
@@ -1,12 +1,14 @@
 package com.dife.api.controller;
 
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
 import com.dife.api.model.ChatroomType;
 import com.dife.api.model.dto.*;
 import com.dife.api.service.ChatroomService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
@@ -26,14 +28,14 @@ public class ChatroomController implements SwaggerChatroomController {
 			ChatroomType chatroomType, Authentication authentication) {
 		List<ChatroomResponseDto> responseDto =
 				chatroomService.getChatrooms(chatroomType, authentication.getName());
-		return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+		return ResponseEntity.status(OK).body(responseDto);
 	}
 
 	@GetMapping("/{id}")
 	public ResponseEntity<ChatroomResponseDto> getGroupChatroom(
 			@PathVariable(name = "id") Long chatroomId) {
 		ChatroomResponseDto responseDto = chatroomService.getChatroom(chatroomId);
-		return ResponseEntity.status(HttpStatus.OK).body(responseDto);
+		return ResponseEntity.status(OK).body(responseDto);
 	}
 
 	@PostMapping
@@ -49,7 +51,7 @@ public class ChatroomController implements SwaggerChatroomController {
 				chatroomService.createChatroom(
 						profileImg, chatroomType, name, description, toMemberId, authentication.getName());
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+		return ResponseEntity.status(CREATED).body(responseDto);
 	}
 
 	@PutMapping(value = "/{id}", consumes = "application/json")
@@ -60,6 +62,6 @@ public class ChatroomController implements SwaggerChatroomController {
 
 		ChatroomResponseDto responseDto =
 				chatroomService.registerDetail(requestDto, chatroomId, auth.getName());
-		return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+		return ResponseEntity.status(OK).body(responseDto);
 	}
 }

--- a/src/main/java/com/dife/api/controller/MemberController.java
+++ b/src/main/java/com/dife/api/controller/MemberController.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -37,7 +36,7 @@ public class MemberController implements SwaggerMemberController {
 			@Valid @RequestBody RegisterEmailAndPasswordRequestDto dto) {
 		RegisterResponseDto responseDto = memberService.registerEmailAndPassword(dto);
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+		return ResponseEntity.status(CREATED).body(responseDto);
 	}
 
 	@GetMapping
@@ -47,7 +46,7 @@ public class MemberController implements SwaggerMemberController {
 		if (isValid) {
 			return ResponseEntity.ok().build();
 		}
-		return ResponseEntity.status(HttpStatus.CONFLICT).build();
+		return ResponseEntity.status(CONFLICT).build();
 	}
 
 	@PutMapping(value = "/{id}", consumes = "multipart/form-data")
@@ -75,7 +74,7 @@ public class MemberController implements SwaggerMemberController {
 						id,
 						profileImg,
 						verificationFile);
-		return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+		return ResponseEntity.status(OK).body(responseDto);
 	}
 
 	@GetMapping("/profile")

--- a/src/main/java/com/dife/api/controller/SocketController.java
+++ b/src/main/java/com/dife/api/controller/SocketController.java
@@ -18,7 +18,7 @@ public class SocketController {
 
 	@MessageMapping("/chatroom/chat")
 	public void sendMessage(ChatRequestDto dto, SimpMessageHeaderAccessor headerAccessor)
-			throws JsonProcessingException, InterruptedException {
+			throws JsonProcessingException {
 		chatService.sendMessage(dto, headerAccessor);
 	}
 }

--- a/src/main/java/com/dife/api/controller/SwaggerChatroomController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerChatroomController.java
@@ -7,11 +7,11 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Chatroom API", description = "채팅방 관리 서비스 API")
 public interface SwaggerChatroomController {
@@ -26,7 +26,12 @@ public interface SwaggerChatroomController {
 						schema = @Schema(implementation = ChatroomResponseDto.class))
 			})
 	ResponseEntity<ChatroomResponseDto> createChatroom(
-			@Valid @RequestBody ChatroomPostRequestDto requestDto, Authentication authentication);
+			@RequestParam(name = "profileImg", required = false) MultipartFile profileImg,
+			@RequestParam(name = "chatroomType") ChatroomType chatroomType,
+			@RequestParam(name = "name", required = false) String name,
+			@RequestParam(name = "description", required = false) String description,
+			@RequestParam(name = "toMemberId", required = false) Long toMemberId,
+			Authentication authentication);
 
 	@Operation(summary = "채팅방 생성2 API", description = "사용자가 DTO를 작성해 PUT요청으로 그룹 채팅방2 생성")
 	@ApiResponse(

--- a/src/main/java/com/dife/api/model/ChatroomSetting.java
+++ b/src/main/java/com/dife/api/model/ChatroomSetting.java
@@ -21,18 +21,18 @@ public class ChatroomSetting {
 	@Size(max = 60)
 	private String description = "";
 
-	private String profileImgName = "";
+	private String profileImgName = "empty";
 
-	@OneToMany(mappedBy = "chatroom_setting", cascade = CascadeType.ALL)
+	@OneToMany(mappedBy = "chatroomSetting", cascade = CascadeType.ALL)
 	private Set<Tag> tags = new HashSet<>();
 
 	private Integer count = 0;
 	private Integer maxCount = 30;
 
-	@OneToMany(mappedBy = "chatroom_setting", cascade = CascadeType.ALL)
+	@OneToMany(mappedBy = "chatroomSetting", cascade = CascadeType.ALL)
 	private Set<GroupPurpose> purposes = new HashSet<>();
 
-	@OneToMany(mappedBy = "chatroom_setting", cascade = CascadeType.ALL)
+	@OneToMany(mappedBy = "chatroomSetting", cascade = CascadeType.ALL)
 	private Set<Language> languages = new HashSet<>();
 
 	private Boolean isPublic = true;

--- a/src/main/java/com/dife/api/model/GroupPurpose.java
+++ b/src/main/java/com/dife/api/model/GroupPurpose.java
@@ -20,5 +20,5 @@ public class GroupPurpose {
 	@ManyToOne
 	@JoinColumn(name = "chatroom_setting_id")
 	@JsonIgnore
-	private ChatroomSetting chatroom_setting;
+	private ChatroomSetting chatroomSetting;
 }

--- a/src/main/java/com/dife/api/model/Language.java
+++ b/src/main/java/com/dife/api/model/Language.java
@@ -25,5 +25,5 @@ public class Language {
 	@ManyToOne
 	@JoinColumn(name = "chatroom_setting_id")
 	@JsonIgnore
-	private ChatroomSetting chatroom_setting;
+	private ChatroomSetting chatroomSetting;
 }

--- a/src/main/java/com/dife/api/model/Tag.java
+++ b/src/main/java/com/dife/api/model/Tag.java
@@ -20,5 +20,5 @@ public class Tag {
 	@ManyToOne
 	@JoinColumn(name = "chatroom_setting_id")
 	@JsonIgnore
-	private ChatroomSetting chatroom_setting;
+	private ChatroomSetting chatroomSetting;
 }

--- a/src/main/java/com/dife/api/model/dto/ChatroomResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/ChatroomResponseDto.java
@@ -3,7 +3,6 @@ package com.dife.api.model.dto;
 import com.dife.api.model.*;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
-import java.util.Map;
 import java.util.Set;
 import lombok.*;
 
@@ -23,9 +22,10 @@ public class ChatroomResponseDto {
 
 	private String description;
 
-	private Map<String, String> activeSessions;
-
 	private String profileImgName;
+
+	@Schema(description = "Presigned S3경로")
+	private String profilePresignUrl;
 
 	private Set<String> tags;
 

--- a/src/main/java/com/dife/api/repository/GroupPurposesRepository.java
+++ b/src/main/java/com/dife/api/repository/GroupPurposesRepository.java
@@ -2,16 +2,11 @@ package com.dife.api.repository;
 
 import com.dife.api.model.ChatroomSetting;
 import com.dife.api.model.GroupPurpose;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GroupPurposesRepository extends JpaRepository<GroupPurpose, Long> {
-
-	@Query(
-			"SELECT COUNT(p) > 0 FROM GroupPurpose p WHERE p.name = :name AND p.chatroom_setting = :chatroomSetting")
-	Boolean existsGroupPurposeByNameAndChatroomSetting(
-			@Param("name") String name, @Param("chatroomSetting") ChatroomSetting chatroomSetting);
+	Set<GroupPurpose> findGroupPurposesByChatroomSetting(ChatroomSetting chatroomSetting);
 }

--- a/src/main/java/com/dife/api/repository/HobbyRepository.java
+++ b/src/main/java/com/dife/api/repository/HobbyRepository.java
@@ -2,13 +2,11 @@ package com.dife.api.repository;
 
 import com.dife.api.model.Hobby;
 import com.dife.api.model.Member;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HobbyRepository extends JpaRepository<Hobby, Long> {
-	@Query("SELECT COUNT(h) > 0 FROM Hobby h WHERE h.name = :name AND h.member = :member")
-	Boolean existsHobbyByNameAndMember(@Param("name") String name, @Param("member") Member member);
+	Set<Hobby> findHobbiesByMember(Member member);
 }

--- a/src/main/java/com/dife/api/repository/LanguageRepository.java
+++ b/src/main/java/com/dife/api/repository/LanguageRepository.java
@@ -3,19 +3,14 @@ package com.dife.api.repository;
 import com.dife.api.model.ChatroomSetting;
 import com.dife.api.model.Language;
 import com.dife.api.model.Member;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LanguageRepository extends JpaRepository<Language, Long> {
 
-	@Query(
-			"SELECT COUNT(l) > 0 FROM Language l WHERE l.name = :name AND l.chatroom_setting = :chatroomSetting")
-	Boolean existsLanguageByNameAndChatroomSetting(
-			@Param("name") String name, @Param("chatroomSetting") ChatroomSetting chatroomSetting);
+	Set<Language> findLanguagesByMember(Member member);
 
-	@Query("SELECT COUNT(l) > 0 FROM Language l WHERE l.name = :name AND l.member = :member")
-	Boolean existsLanguageByNameAndMember(@Param("name") String name, @Param("member") Member member);
+	Set<Language> findLanguagesByChatroomSetting(ChatroomSetting chatroomSetting);
 }

--- a/src/main/java/com/dife/api/repository/TagRepository.java
+++ b/src/main/java/com/dife/api/repository/TagRepository.java
@@ -1,16 +1,12 @@
 package com.dife.api.repository;
 
 import com.dife.api.model.*;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
-	@Query(
-			"SELECT COUNT(t) > 0 FROM Tag t WHERE t.name = :name AND t.chatroom_setting = :chatroomSetting")
-	Boolean existsTagByNameAndChatroomSetting(
-			@Param("name") String name, @Param("chatroomSetting") ChatroomSetting chatroomSetting);
+	Set<Tag> findTagsByChatroomSetting(ChatroomSetting chatroomSetting);
 }

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -6,8 +6,12 @@ import com.dife.api.exception.*;
 import com.dife.api.model.*;
 import com.dife.api.model.dto.*;
 import com.dife.api.repository.*;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -15,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -53,23 +58,29 @@ public class ChatroomService {
 				.collect(toList());
 	}
 
-	public ChatroomResponseDto createChatroom(ChatroomPostRequestDto requestDto, String memberEmail) {
-		switch (requestDto.getChatroomType()) {
+	public ChatroomResponseDto createChatroom(
+			MultipartFile profileImg,
+			ChatroomType chatroomType,
+			String name,
+			String description,
+			Long toMemberId,
+			String memberEmail) {
+		switch (chatroomType) {
 			case GROUP:
-				return createGroupChatroom(requestDto, memberEmail);
+				return createGroupChatroom(profileImg, name, description, memberEmail);
 			case SINGLE:
-				return createSingleChatroom(requestDto, memberEmail);
+				return createSingleChatroom(toMemberId, memberEmail);
 		}
 		throw new ChatroomException("유효한 채팅방 생성 접근이 아닙니다!");
 	}
 
 	public ChatroomResponseDto createGroupChatroom(
-			ChatroomPostRequestDto requestDto, String memberEmail) {
+			MultipartFile profileImg, String name, String description, String memberEmail) {
 
 		Member member =
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 
-		String trimmedName = requestDto.getName().trim();
+		String trimmedName = name.trim();
 		if (chatroomRepository.existsByName(trimmedName)) throw new ChatroomDuplicateException();
 		if (trimmedName.isEmpty()) throw new ChatroomException("채팅방 이름은 필수사항입니다.");
 
@@ -81,7 +92,7 @@ public class ChatroomService {
 		chatroom.setChatroomType(ChatroomType.GROUP);
 
 		ChatroomSetting setting = new ChatroomSetting();
-		String trimmedDescription = requestDto.getDescription().trim();
+		String trimmedDescription = description.trim();
 		if (trimmedDescription.isEmpty())
 			throw new ChatroomException("유효하지 않은 한줄소개입니다. 공백만 존재하는 한줄 소개는 허용되지 않습니다.");
 
@@ -91,6 +102,12 @@ public class ChatroomService {
 
 		chatroomRepository.save(chatroom);
 
+		if (profileImg == null || profileImg.isEmpty() || setting.getProfileImgName().isEmpty())
+			setting.setProfileImgName("empty");
+		else {
+			FileDto profileImgPath = fileService.upload(profileImg);
+			setting.setProfileImgName(profileImgPath.getOriginalName());
+		}
 		return chatroomModelMapper.map(chatroom, ChatroomResponseDto.class);
 	}
 
@@ -172,7 +189,7 @@ public class ChatroomService {
 				nPurpose.setName(groupPurposeName);
 				nPurpose.setChatroomSetting(setting);
 				groupPurposesRepository.save(nPurpose);
-				myGroupPurposes.add(nPurpose);
+				updatedGroupPurposes.add(nPurpose);
 			}
 		}
 		existingGroupPurposes.stream()
@@ -193,15 +210,12 @@ public class ChatroomService {
 		return chatroomModelMapper.map(chatroom, ChatroomResponseDto.class);
 	}
 
-	public ChatroomResponseDto createSingleChatroom(
-			ChatroomPostRequestDto requestDto, String currentMemberEmail) {
+	public ChatroomResponseDto createSingleChatroom(Long toMemberId, String currentMemberEmail) {
 
 		Member currentMember =
 				memberRepository.findByEmail(currentMemberEmail).orElseThrow(MemberNotFoundException::new);
 		Member otherMember =
-				memberRepository
-						.findById(requestDto.getMemberId())
-						.orElseThrow(MemberNotFoundException::new);
+				memberRepository.findById(toMemberId).orElseThrow(MemberNotFoundException::new);
 
 		if (chatroomRepository.existsSingleChatroomByMembers(
 				currentMember, otherMember, ChatroomType.SINGLE))
@@ -224,7 +238,11 @@ public class ChatroomService {
 	public ChatroomResponseDto getChatroom(Long id) {
 
 		Chatroom chatroom = chatroomRepository.findById(id).orElseThrow(ChatroomNotFoundException::new);
-		return chatroomModelMapper.map(chatroom, ChatroomResponseDto.class);
+		ChatroomSetting setting = chatroom.getChatroomSetting();
+		ChatroomResponseDto responseDto = chatroomModelMapper.map(chatroom, ChatroomResponseDto.class);
+
+		responseDto.setProfilePresignUrl(fileService.getPresignUrl(setting.getProfileImgName()));
+		return responseDto;
 	}
 
 	public List<ChatResponseDto> getChats(Long chatroomId, String memberEmail) {


### PR DESCRIPTION
#### 개요
- 기존의 태그 (회원에 따른 유일한 언어 or 취미) 좋게 개선한 코드와
- 그룹 채팅방에 이미지 업로드를 위한 코드를 반영한 PR입니다!
- 기존의 태그 로직은 변경된 태그들과 기존의 태그들이 겹쳐 수정 사항을 반영하지 못한다는 문제점을 찾아 개선했습니다.
- 프로필 이미지는` GET` 요청 시에만 presign URL이 보이도록 할 예정입니다!
- 자세한 내용은 커밋별 참고 부탁드립니다!

### 시나리오
- 언어에` "KOREAN", "ENLGISH"` 입력
- PUT 전송
- `"KOREAN"`만 다시 입력
- PUT 전송
-` "ENLGISH`"만 다시 입력
- PUT 전송


#### 추후 진행 사항
- 수정 요청 파라미터 검토 및 개선