### PR TITLE
fix/member-post: 학생증 인증 파일 required 해제

### DIFF
--- a/src/main/java/com/dife/api/config/MapperConfig.java
+++ b/src/main/java/com/dife/api/config/MapperConfig.java
@@ -38,8 +38,8 @@ public class MapperConfig {
 				.addMappings(
 						mapper -> {
 							mapper.map(
-									src -> src.getChatroomSetting().getProfileImgName(),
-									ChatroomResponseDto::setProfileImgName);
+									src -> src.getChatroomSetting().getProfileImg(),
+									ChatroomResponseDto::setProfileImg);
 							mapper.map(
 									src -> src.getChatroomSetting().getDescription(),
 									ChatroomResponseDto::setDescription);
@@ -100,7 +100,7 @@ public class MapperConfig {
 							mapper.map(Member::getBio, MemberResponseDto::setBio);
 							mapper.map(Member::getMbti, MemberResponseDto::setMbti);
 							mapper.map(Member::getIsPublic, MemberResponseDto::setIsPublic);
-							mapper.map(Member::getProfileFileName, MemberResponseDto::setProfileFileName);
+							mapper.map(Member::getProfileImg, MemberResponseDto::setProfileImg);
 							mapper.map(Member::getIsVerified, MemberResponseDto::setIsVerified);
 
 							mapper.map(

--- a/src/main/java/com/dife/api/controller/ChatroomController.java
+++ b/src/main/java/com/dife/api/controller/ChatroomController.java
@@ -62,7 +62,7 @@ public class ChatroomController implements SwaggerChatroomController {
 			Authentication auth) {
 
 		ChatroomResponseDto responseDto =
-				chatroomService.registerDetail(requestDto, chatroomId, auth.getName());
+				chatroomService.update(requestDto, chatroomId, auth.getName());
 		return ResponseEntity.status(OK).body(responseDto);
 	}
 

--- a/src/main/java/com/dife/api/controller/MemberController.java
+++ b/src/main/java/com/dife/api/controller/MemberController.java
@@ -56,7 +56,7 @@ public class MemberController implements SwaggerMemberController {
 			@RequestParam(name = "hobbies", required = false) Set<String> hobbies,
 			@RequestParam(name = "languages", required = false) Set<String> languages,
 			@RequestParam(name = "profileImg", required = false) MultipartFile profileImg,
-			@RequestParam(name = "verificationFile") MultipartFile verificationFile,
+			@RequestParam(name = "verificationFile", required = false) MultipartFile verificationFile,
 			@RequestParam(name = "isPublic", required = false) Boolean isPublic,
 			@PathVariable(name = "id") Long id) {
 

--- a/src/main/java/com/dife/api/controller/MemberController.java
+++ b/src/main/java/com/dife/api/controller/MemberController.java
@@ -61,7 +61,7 @@ public class MemberController implements SwaggerMemberController {
 			@PathVariable(name = "id") Long id) {
 
 		MemberResponseDto responseDto =
-				memberService.registerDetail(
+				memberService.update(
 						username,
 						isKorean,
 						bio,

--- a/src/main/java/com/dife/api/jwt/JWTFilter.java
+++ b/src/main/java/com/dife/api/jwt/JWTFilter.java
@@ -47,7 +47,7 @@ public class JWTFilter extends OncePerRequestFilter {
 				Member member =
 						memberRepository.findById(id).orElseThrow(() -> new MemberException("회원을 찾을 수 없습니다!"));
 
-				if (!member.getVerificationFileName().equals("empty") && !member.getIsVerified())
+				if (member.getVerificationFile() != null && !member.getIsVerified())
 					throw new MemberException("인증받지 않은 회원입니다!");
 
 				CustomUserDetails customUserDetails = new CustomUserDetails(member);

--- a/src/main/java/com/dife/api/model/ChatroomSetting.java
+++ b/src/main/java/com/dife/api/model/ChatroomSetting.java
@@ -21,7 +21,7 @@ public class ChatroomSetting {
 	@Size(max = 60)
 	private String description = "";
 
-	private String profileImgName = "empty";
+	@OneToOne private File profileImg;
 
 	@OneToMany(mappedBy = "chatroomSetting", cascade = CascadeType.ALL)
 	private Set<Hobby> hobbies = new HashSet<>();

--- a/src/main/java/com/dife/api/model/Comment.java
+++ b/src/main/java/com/dife/api/model/Comment.java
@@ -22,8 +22,6 @@ public class Comment extends BaseTimeEntity {
 
 	private Boolean isPublic = true;
 
-	private Integer viewCount = 0;
-
 	@ManyToOne(fetch = FetchType.EAGER)
 	@JoinColumn(name = "writer_id")
 	private Member writer;

--- a/src/main/java/com/dife/api/model/Member.java
+++ b/src/main/java/com/dife/api/model/Member.java
@@ -36,7 +36,7 @@ public class Member extends BaseTimeEntity {
 
 	private String role = "user";
 
-	private String verificationFileName = "empty";
+	@OneToOne private File verificationFile;
 
 	private Boolean isKorean = true;
 
@@ -51,7 +51,7 @@ public class Member extends BaseTimeEntity {
 	@OneToMany(mappedBy = "member", fetch = FetchType.EAGER)
 	private Set<Hobby> hobbies = new HashSet<>();
 
-	private String profileFileName = "empty";
+	@OneToOne private File profileImg;
 
 	@Size(max = 60, message = "자기소개는 최대 60자까지 입력 가능합니다.")
 	private String bio = "";

--- a/src/main/java/com/dife/api/model/Post.java
+++ b/src/main/java/com/dife/api/model/Post.java
@@ -25,8 +25,6 @@ public class Post extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private BoardCategory boardType = BoardCategory.FREE;
 
-	private Integer viewCount = 0;
-
 	@ManyToOne
 	@JoinColumn(name = "member_id")
 	private Member member;

--- a/src/main/java/com/dife/api/model/dto/ChatroomResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/ChatroomResponseDto.java
@@ -22,7 +22,7 @@ public class ChatroomResponseDto {
 
 	private String description;
 
-	private String profileImgName;
+	private File profileImg;
 
 	@Schema(description = "Presigned S3경로")
 	private String profilePresignUrl;

--- a/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
@@ -23,8 +23,6 @@ public class CommentResponseDto {
 
 	private Integer likesCount;
 
-	private Integer viewCount;
-
 	@JsonProperty("writer")
 	private Member writer;
 

--- a/src/main/java/com/dife/api/model/dto/MemberResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/MemberResponseDto.java
@@ -1,5 +1,6 @@
 package com.dife.api.model.dto;
 
+import com.dife.api.model.File;
 import com.dife.api.model.MbtiCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -47,7 +48,7 @@ public class MemberResponseDto {
 	private Set<String> hobbies;
 
 	@Schema(description = "S3에 저장되는 프로필 이미지", example = "cookie.jpeg")
-	private String profileFileName;
+	private File profileImg;
 
 	@Schema(description = "Presigned S3경로")
 	private String profilePresignUrl;

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -99,19 +99,15 @@ public class ChatroomService {
 
 		chatroomRepository.save(chatroom);
 
-		if ("empty".equals(setting.getProfileImgName())
-				&& (profileImg == null || profileImg.isEmpty())) {
-			setting.setProfileImgName("empty");
-		} else {
-			if (profileImg != null && !profileImg.isEmpty()) {
-				FileDto profileImgPath = fileService.upload(profileImg);
-				setting.setProfileImgName(profileImgPath.getOriginalName());
-			}
+		if (profileImg != null && !profileImg.isEmpty()) {
+			FileDto profileImgPath = fileService.upload(profileImg);
+			File file = modelMapper.map(profileImgPath, File.class);
+			setting.setProfileImg(file);
 		}
 		return chatroomModelMapper.map(chatroom, ChatroomResponseDto.class);
 	}
 
-	public ChatroomResponseDto registerDetail(
+	public ChatroomResponseDto update(
 			GroupChatroomPutRequestDto requestDto, Long chatroomId, String memberEmail) {
 
 		Chatroom chatroom =
@@ -240,8 +236,9 @@ public class ChatroomService {
 		Chatroom chatroom = chatroomRepository.findById(id).orElseThrow(ChatroomNotFoundException::new);
 		ChatroomSetting setting = chatroom.getChatroomSetting();
 		ChatroomResponseDto responseDto = chatroomModelMapper.map(chatroom, ChatroomResponseDto.class);
+		responseDto.setProfilePresignUrl(
+				fileService.getPresignUrl(setting.getProfileImg().getOriginalName()));
 
-		responseDto.setProfilePresignUrl(fileService.getPresignUrl(setting.getProfileImgName()));
 		return responseDto;
 	}
 
@@ -345,7 +342,8 @@ public class ChatroomService {
 		for (Chatroom chatroom : validChatrooms) {
 			ChatroomResponseDto chatroomResponseDto =
 					chatroomModelMapper.map(chatroom, ChatroomResponseDto.class);
-			chatroomResponseDto.setProfilePresignUrl(chatroom.getChatroomSetting().getProfileImgName());
+			chatroomResponseDto.setProfilePresignUrl(
+					chatroom.getChatroomSetting().getProfileImg().getOriginalName());
 			chatroomResponseDtos.add(chatroomResponseDto);
 		}
 		return chatroomResponseDtos;
@@ -363,7 +361,8 @@ public class ChatroomService {
 							ChatroomResponseDto chatroomResponseDto =
 									chatroomModelMapper.map(chatroom, ChatroomResponseDto.class);
 							chatroomResponseDto.setProfilePresignUrl(
-									fileService.getPresignUrl(chatroom.getChatroomSetting().getProfileImgName()));
+									fileService.getPresignUrl(
+											chatroom.getChatroomSetting().getProfileImg().getOriginalName()));
 							return chatroomResponseDto;
 						})
 				.collect(Collectors.toList());

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -80,7 +80,7 @@ public class MemberService {
 		return true;
 	}
 
-	public MemberResponseDto registerDetail(
+	public MemberResponseDto update(
 			String username,
 			Boolean isKorean,
 			String bio,
@@ -93,30 +93,27 @@ public class MemberService {
 			MultipartFile verificationFile) {
 		Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
 
-		if ("empty".equals(member.getVerificationFileName())
-				&& (verificationFile == null || verificationFile.isEmpty())) {
+		if ((verificationFile.isEmpty() || verificationFile == null)
+				&& (member.getUsername().equals(""))) {
 			throw new MemberNotAddVerificationException();
 		} else {
 			if (verificationFile != null && !verificationFile.isEmpty()) {
 				FileDto verificationImgPath = fileService.upload(verificationFile);
-				member.setVerificationFileName(verificationImgPath.getName());
+				File file = modelMapper.map(verificationImgPath, File.class);
+				member.setVerificationFile(file);
 			}
 		}
 
-		if ("empty".equals(member.getProfileFileName())
-				&& (profileImg == null || profileImg.isEmpty())) {
-			member.setProfileFileName("empty");
-		} else {
-			if (profileImg != null && !profileImg.isEmpty()) {
-				FileDto profileImgPath = fileService.upload(profileImg);
-				member.setProfileFileName(profileImgPath.getOriginalName());
-			}
+		if (profileImg != null && !profileImg.isEmpty()) {
+			FileDto profileImgPath = fileService.upload(profileImg);
+			File file = modelMapper.map(profileImgPath, File.class);
+			member.setProfileImg(file);
 		}
 
-		member.setUsername(username);
-		member.setIsKorean(isKorean);
-		member.setBio(bio);
-		member.setMbti(mbti);
+		if (username != null && !username.isEmpty()) member.setUsername(username);
+		if (isKorean != null && isKorean != member.getIsKorean()) member.setIsKorean(isKorean);
+		if (bio != null && !bio.isEmpty()) member.setBio(bio);
+		if (mbti != null && !mbti.equals(member.getMbti())) member.setMbti(mbti);
 
 		Set<String> safeHobbies = hobbies != null ? hobbies : Collections.emptySet();
 		Set<String> safeLanguages = languages != null ? languages : Collections.emptySet();
@@ -168,7 +165,7 @@ public class MemberService {
 
 		member.setLanguages(updatedLanguages);
 
-		member.setIsPublic(isPublic);
+		if (isPublic != null && isPublic != member.getIsPublic()) member.setIsPublic(isPublic);
 		memberRepository.save(member);
 
 		return memberModelMapper.map(member, MemberResponseDto.class);
@@ -204,7 +201,8 @@ public class MemberService {
 		Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
 		MemberResponseDto responseDto = memberModelMapper.map(member, MemberResponseDto.class);
 
-		responseDto.setProfilePresignUrl(fileService.getPresignUrl(member.getProfileFileName()));
+		responseDto.setProfilePresignUrl(
+				fileService.getPresignUrl(member.getProfileImg().getOriginalName()));
 		return responseDto;
 	}
 
@@ -213,7 +211,8 @@ public class MemberService {
 		Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 		MemberResponseDto responseDto = memberModelMapper.map(member, MemberResponseDto.class);
 
-		responseDto.setProfilePresignUrl(fileService.getPresignUrl(member.getProfileFileName()));
+		responseDto.setProfilePresignUrl(
+				fileService.getPresignUrl(member.getProfileImg().getOriginalName()));
 		return responseDto;
 	}
 
@@ -262,7 +261,8 @@ public class MemberService {
 		List<MemberResponseDto> memberResponseDtos = new ArrayList<>();
 		for (Member member : randomMembers) {
 			MemberResponseDto responseDto = memberModelMapper.map(member, MemberResponseDto.class);
-			responseDto.setProfilePresignUrl(fileService.getPresignUrl(member.getProfileFileName()));
+			responseDto.setProfilePresignUrl(
+					fileService.getPresignUrl(member.getProfileImg().getOriginalName()));
 			memberResponseDtos.add(responseDto);
 		}
 		return memberResponseDtos;
@@ -291,7 +291,8 @@ public class MemberService {
 		List<MemberResponseDto> memberResponseDtos = new ArrayList<>();
 		for (Member member : validMembers) {
 			MemberResponseDto responseDto = memberModelMapper.map(member, MemberResponseDto.class);
-			responseDto.setProfilePresignUrl(fileService.getPresignUrl(member.getProfileFileName()));
+			responseDto.setProfilePresignUrl(
+					fileService.getPresignUrl(member.getProfileImg().getOriginalName()));
 			memberResponseDtos.add(responseDto);
 		}
 		return memberResponseDtos;
@@ -311,7 +312,7 @@ public class MemberService {
 							MemberResponseDto responseDto =
 									memberModelMapper.map(member, MemberResponseDto.class);
 							responseDto.setProfilePresignUrl(
-									fileService.getPresignUrl(member.getProfileFileName()));
+									fileService.getPresignUrl(member.getProfileImg().getOriginalName()));
 							return responseDto;
 						})
 				.collect(Collectors.toList());


### PR DESCRIPTION
### 개요
- Update 메서드를 고도화 시킨 PR입니다!


**변경된 내용**
- required 되어있던 학생증 인증 파일 required 해제
- 불필요한 게시글 관련 viewCount 삭제
- 파일 초기값 null 화 및 엔티티화 (모든 파일에 한해)
- 기존 값과 변화가 없거나 null 값이 들어온다면 update 기능에 맞춰 기존값 유지
- 자세한 내용은 커밋별로 확인 부탁드립니다! :)

 **!학생증 인증 부분 변경 로직!**
- 기존의 학생증 인증 파일 초기값을 "empty"로 설정해 인증 처리를 해왔는데
- file 엔티티 사용으로 인해 약간의 변경사항이 있을 것 같습니다..!

**1. 온보딩 완료 회원 / 미완료 회원 구분 -> 
온보딩 완료 회원 : /profile의 ResponseDTO의 username != ""
온보딩 미완료 회원 : /profile의 ResponseDTO의 username == ""**