### PR TITLE
Feat/notification : 알림 서비스 세팅

### DIFF
--- a/src/main/java/com/dife/api/controller/NotificationController.java
+++ b/src/main/java/com/dife/api/controller/NotificationController.java
@@ -1,0 +1,33 @@
+package com.dife.api.controller;
+
+import com.dife.api.model.dto.NotificationResponseDto;
+import com.dife.api.service.NotificationService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+	private final NotificationService notificationService;
+
+	@GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public SseEmitter streamNotifications(Authentication auth) {
+		return notificationService.createEmitter(auth.getName());
+	}
+
+	@GetMapping
+	public ResponseEntity<List<NotificationResponseDto>> getNotifications(Authentication auth) {
+		List<NotificationResponseDto> responseDtos =
+				notificationService.getNotifications(auth.getName());
+		return ResponseEntity.ok(responseDtos);
+	}
+}

--- a/src/main/java/com/dife/api/exception/NotificationException.java
+++ b/src/main/java/com/dife/api/exception/NotificationException.java
@@ -1,0 +1,8 @@
+package com.dife.api.exception;
+
+public class NotificationException extends RuntimeException {
+
+	public NotificationException() {
+		super("알림 전송에 문제가 있습니다!");
+	}
+}

--- a/src/main/java/com/dife/api/model/Member.java
+++ b/src/main/java/com/dife/api/model/Member.java
@@ -85,4 +85,8 @@ public class Member extends BaseTimeEntity {
 	@OneToMany(mappedBy = "member", fetch = FetchType.EAGER)
 	@JsonIgnore
 	private List<PostLike> PostLikes;
+
+	@OneToMany(mappedBy = "member", fetch = FetchType.EAGER)
+	@JsonIgnore
+	private List<Notification> notifications;
 }

--- a/src/main/java/com/dife/api/model/Notification.java
+++ b/src/main/java/com/dife/api/model/Notification.java
@@ -1,0 +1,26 @@
+package com.dife.api.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "notification")
+public class Notification extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private NotificationType type;
+
+	private String message;
+
+	private Boolean isRead = false;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	private Member member;
+}

--- a/src/main/java/com/dife/api/model/NotificationType.java
+++ b/src/main/java/com/dife/api/model/NotificationType.java
@@ -1,0 +1,6 @@
+package com.dife.api.model;
+
+public enum NotificationType {
+	POST,
+	CHAT
+}

--- a/src/main/java/com/dife/api/model/dto/NotificationResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/NotificationResponseDto.java
@@ -1,0 +1,21 @@
+package com.dife.api.model.dto;
+
+import com.dife.api.model.NotificationType;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NotificationResponseDto {
+
+	private Long id;
+
+	private NotificationType type;
+
+	private String message;
+
+	private Boolean isRead;
+
+	private LocalDateTime created;
+}

--- a/src/main/java/com/dife/api/repository/NotificationRepository.java
+++ b/src/main/java/com/dife/api/repository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package com.dife.api.repository;
+
+import com.dife.api.model.Member;
+import com.dife.api.model.Notification;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+	List<Notification> findAllByMember(Member member);
+}

--- a/src/main/java/com/dife/api/service/NotificationService.java
+++ b/src/main/java/com/dife/api/service/NotificationService.java
@@ -1,0 +1,102 @@
+package com.dife.api.service;
+
+import static java.util.stream.Collectors.toList;
+
+import com.dife.api.exception.MemberNotFoundException;
+import com.dife.api.exception.NotificationException;
+import com.dife.api.model.Member;
+import com.dife.api.model.Notification;
+import com.dife.api.model.NotificationType;
+import com.dife.api.model.dto.NotificationResponseDto;
+import com.dife.api.repository.MemberRepository;
+import com.dife.api.repository.NotificationRepository;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class NotificationService {
+
+	private final Map<Long, SseEmitter> memberEmitters = new ConcurrentHashMap<>();
+	private static final long RECONNECTION_TIMEOUT = 1000L;
+	private final ModelMapper modelMapper;
+
+	private final MemberRepository memberRepository;
+	private final NotificationRepository notificationRepository;
+
+	public SseEmitter createEmitter(String memberEmail) {
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
+		SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+		memberEmitters.put(member.getId(), emitter);
+
+		emitter.onCompletion(() -> memberEmitters.remove(member.getId()));
+		emitter.onTimeout(() -> memberEmitters.remove(member.getId()));
+		emitter.onError((e) -> memberEmitters.remove(member.getId()));
+
+		try {
+			SseEmitter.SseEventBuilder event =
+					SseEmitter.event()
+							.name("notification")
+							.id(String.valueOf("id-1"))
+							.data("SSE connected")
+							.reconnectTime(RECONNECTION_TIMEOUT);
+			emitter.send(event);
+		} catch (IOException e) {
+			throw new NotificationException();
+		}
+
+		return emitter;
+	}
+
+	public void sendNotification(String memberEmail, NotificationType type, String message) {
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
+
+		Notification notification = new Notification();
+		notification.setType(type);
+		notification.setMessage(message);
+		notification.setMember(member);
+		notificationRepository.save(notification);
+
+		sendRealTimeNotification(notification, member.getId());
+	}
+
+	private void sendRealTimeNotification(Notification notification, Long memberId) {
+		SseEmitter emitter = memberEmitters.get(memberId);
+
+		if (emitter != null) {
+			Executors.newSingleThreadExecutor()
+					.execute(
+							() -> {
+								try {
+									emitter.send(
+											SseEmitter.event().name("notification").data(notification.getMessage()));
+								} catch (Exception e) {
+									throw new NotificationException();
+								}
+							});
+		}
+	}
+
+	public List<NotificationResponseDto> getNotifications(String memberEmail) {
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
+		List<Notification> notifications = notificationRepository.findAllByMember(member);
+
+		return notifications.stream()
+				.map(n -> modelMapper.map(n, NotificationResponseDto.class))
+				.collect(toList());
+	}
+}

--- a/src/main/java/com/dife/api/service/PostService.java
+++ b/src/main/java/com/dife/api/service/PostService.java
@@ -6,6 +6,7 @@ import com.dife.api.exception.MemberNotFoundException;
 import com.dife.api.exception.PostNotFoundException;
 import com.dife.api.model.BoardCategory;
 import com.dife.api.model.Member;
+import com.dife.api.model.NotificationType;
 import com.dife.api.model.Post;
 import com.dife.api.model.dto.*;
 import com.dife.api.repository.MemberRepository;
@@ -27,6 +28,7 @@ public class PostService {
 	private final PostRepository postRepository;
 	private final MemberRepository memberRepository;
 	private final ModelMapper modelMapper;
+	private final NotificationService notificationService;
 
 	public PostResponseDto createPost(PostCreateRequestDto requestDto, String memberEmail) {
 
@@ -41,6 +43,7 @@ public class PostService {
 		post.setMember(member);
 
 		postRepository.save(post);
+		notificationService.sendNotification(memberEmail, NotificationType.POST, "게시글이 생성되었습니다!");
 
 		return modelMapper.map(post, PostResponseDto.class);
 	}


### PR DESCRIPTION
### 개요
- SSE를 기반으로 한 알림서비스 초기 세팅 PR입니다! 
- 웹소켓과 유사하게 구독 -> 전송 구조로 되어있습니다.
- 엔티티의 구성 요소는 이전에 slack에서 공지한 바와 같습니다!
- 추가적으로 회원별 알림 List를 확인하는 메서드도 포함되어 있습니다.

#### 고려 사항
- 다른 서버에서 온 알람의 경우 이전에 채팅에서 사용했던 방법처럼 Redis를 이용해 해당 뿌려줄 것인지?!

#### 테스트
- 회원가입1 -> 로그인
- SSE 연결 (GET mapping)
- 게시글 생성 
- SSE 확인
<img width="600" alt="스크린샷 2024-06-27 오후 1 12 45" src="https://github.com/team-diverse/dife-backend/assets/124496650/ba5a66df-b64b-4c79-8281-cfa47eb938c7">

#### 추후 진행 사항
- 피드백 반영
- 다른 서비스에도 알림 적용 
