### PR TITLE
Refactor/post-file-member : 파일 엔드포인트 분리 사용 및 회원 본인이 작성한 글 조회 API 추가

### DIFF
--- a/src/main/java/com/dife/api/controller/FileController.java
+++ b/src/main/java/com/dife/api/controller/FileController.java
@@ -12,13 +12,18 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/files")
-public class FileController {
+public class FileController implements SwaggerFileController {
 
 	private final FileService fileService;
 
-	@PostMapping("/")
-	ResponseEntity<FileDto> uploadFile(@RequestParam(name = "file") MultipartFile file) {
+	@PostMapping(consumes = "multipart/form-data")
+	public ResponseEntity<FileDto> uploadFile(@RequestParam(name = "file") MultipartFile file) {
 		FileDto dto = fileService.upload(file);
 		return ResponseEntity.status(CREATED).body(dto);
+	}
+
+	@GetMapping
+	public ResponseEntity<String> getFile(@RequestParam(name = "fileName") String fileName) {
+		return ResponseEntity.ok(fileService.getPresignUrl(fileName));
 	}
 }

--- a/src/main/java/com/dife/api/controller/FileController.java
+++ b/src/main/java/com/dife/api/controller/FileController.java
@@ -2,10 +2,12 @@ package com.dife.api.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
+import com.dife.api.model.FileLocation;
 import com.dife.api.model.dto.FileDto;
 import com.dife.api.service.FileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,8 +19,12 @@ public class FileController implements SwaggerFileController {
 	private final FileService fileService;
 
 	@PostMapping(consumes = "multipart/form-data")
-	public ResponseEntity<FileDto> uploadFile(@RequestParam(name = "file") MultipartFile file) {
-		FileDto dto = fileService.upload(file);
+	public ResponseEntity<FileDto> uploadFile(
+			@RequestParam(name = "fileLocation") FileLocation fileLocation,
+			@RequestParam(name = "id") Long id,
+			@RequestParam(name = "file") MultipartFile file,
+			Authentication auth) {
+		FileDto dto = fileService.uploadFileLocation(file, fileLocation, id, auth.getName());
 		return ResponseEntity.status(CREATED).body(dto);
 	}
 

--- a/src/main/java/com/dife/api/controller/FileController.java
+++ b/src/main/java/com/dife/api/controller/FileController.java
@@ -1,16 +1,9 @@
 package com.dife.api.controller;
 
-import static org.springframework.http.HttpStatus.CREATED;
-import static org.springframework.http.HttpStatus.OK;
-
-import com.dife.api.model.FileLocation;
-import com.dife.api.model.dto.FileDto;
 import com.dife.api.service.FileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,27 +12,8 @@ public class FileController implements SwaggerFileController {
 
 	private final FileService fileService;
 
-	@PostMapping(consumes = "multipart/form-data")
-	public ResponseEntity<FileDto> uploadFile(
-			@RequestParam(name = "fileLocation") FileLocation fileLocation,
-			@RequestParam(name = "id") Long id,
-			@RequestParam(name = "file") MultipartFile file,
-			Authentication auth) {
-		FileDto dto = fileService.uploadFileLocation(file, fileLocation, id, auth.getName());
-		return ResponseEntity.status(CREATED).body(dto);
-	}
-
 	@GetMapping
 	public ResponseEntity<String> getFile(@RequestParam(name = "fileName") String fileName) {
 		return ResponseEntity.ok(fileService.getPresignUrl(fileName));
-	}
-
-	@DeleteMapping("/{id}")
-	public ResponseEntity<Void> deleteFile(
-			@PathVariable(name = "id") Long id,
-			@RequestParam(name = "fileLocation") FileLocation fileLocation,
-			Authentication auth) {
-		fileService.deleteFileLocation(id, fileLocation, auth.getName());
-		return new ResponseEntity<>(OK);
 	}
 }

--- a/src/main/java/com/dife/api/controller/FileController.java
+++ b/src/main/java/com/dife/api/controller/FileController.java
@@ -1,6 +1,7 @@
 package com.dife.api.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 import com.dife.api.model.FileLocation;
 import com.dife.api.model.dto.FileDto;
@@ -31,5 +32,14 @@ public class FileController implements SwaggerFileController {
 	@GetMapping
 	public ResponseEntity<String> getFile(@RequestParam(name = "fileName") String fileName) {
 		return ResponseEntity.ok(fileService.getPresignUrl(fileName));
+	}
+
+	@DeleteMapping("/{id}")
+	public ResponseEntity<Void> deleteFile(
+			@PathVariable(name = "id") Long id,
+			@RequestParam(name = "fileLocation") FileLocation fileLocation,
+			Authentication auth) {
+		fileService.deleteFileLocation(id, fileLocation, auth.getName());
+		return new ResponseEntity<>(OK);
 	}
 }

--- a/src/main/java/com/dife/api/controller/MemberController.java
+++ b/src/main/java/com/dife/api/controller/MemberController.java
@@ -132,4 +132,10 @@ public class MemberController implements SwaggerMemberController {
 		List<MemberResponseDto> responseDto = memberService.getSearchMembers(keyword);
 		return ResponseEntity.ok(responseDto);
 	}
+
+	@GetMapping("/posts")
+	public ResponseEntity<List<PostResponseDto>> getMemberPosts(Authentication auth) {
+		List<PostResponseDto> responseDto = memberService.getMemberPosts(auth.getName());
+		return ResponseEntity.ok(responseDto);
+	}
 }

--- a/src/main/java/com/dife/api/controller/PostController.java
+++ b/src/main/java/com/dife/api/controller/PostController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,11 +26,17 @@ public class PostController implements SwaggerPostController {
 		return ResponseEntity.status(OK).body(responseDto);
 	}
 
-	@PostMapping(consumes = "application/json")
+	@PostMapping(consumes = "multipart/form-data")
 	public ResponseEntity<PostResponseDto> createPost(
-			@RequestBody PostCreateRequestDto requestDto, Authentication auth) {
+			@RequestParam(name = "title") String title,
+			@RequestParam(name = "content") String content,
+			@RequestParam(name = "isPublic") Boolean isPublic,
+			@RequestParam(name = "boardType") BoardCategory boardType,
+			@RequestParam(name = "postFile", required = false) MultipartFile postFile,
+			Authentication auth) {
 
-		PostResponseDto responseDto = postService.createPost(requestDto, auth.getName());
+		PostResponseDto responseDto =
+				postService.createPost(title, content, isPublic, boardType, postFile, auth.getName());
 
 		return ResponseEntity.status(CREATED).body(responseDto);
 	}
@@ -40,12 +47,17 @@ public class PostController implements SwaggerPostController {
 		return ResponseEntity.status(OK).body(responseDto);
 	}
 
-	@PutMapping(value = "/{id}", consumes = "application/json")
+	@PutMapping(value = "/{id}", consumes = "multipart/form-data")
 	public ResponseEntity<PostResponseDto> updatePost(
 			@PathVariable(name = "id") Long id,
-			@RequestBody PostUpdateRequestDto requestDto,
+			@RequestParam(name = "title", required = false) String title,
+			@RequestParam(name = "content", required = false) String content,
+			@RequestParam(name = "isPublic", required = false) Boolean isPublic,
+			@RequestParam(name = "boardType", required = false) BoardCategory boardType,
+			@RequestParam(name = "postFile", required = false) MultipartFile postFile,
 			Authentication auth) {
-		PostResponseDto responseDto = postService.updatePost(id, requestDto, auth.getName());
+		PostResponseDto responseDto =
+				postService.updatePost(id, title, content, isPublic, boardType, postFile, auth.getName());
 		return ResponseEntity.status(OK).body(responseDto);
 	}
 

--- a/src/main/java/com/dife/api/controller/SwaggerFileController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerFileController.java
@@ -1,0 +1,33 @@
+package com.dife.api.controller;
+
+import com.dife.api.model.dto.FileDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "File API", description = "파일 서비스 API")
+public interface SwaggerFileController {
+
+	@Operation(
+			summary = "파일 업로드 API",
+			description = "사용자가 파일을 업로드 해 Dife S3 Bucket에 파일을 저장하는 API입니다.")
+	@ApiResponse(
+			responseCode = "200",
+			description = "파일 업로드 성공 예시",
+			content = {
+				@Content(mediaType = "application/json", schema = @Schema(implementation = FileDto.class))
+			})
+	ResponseEntity<FileDto> uploadFile(@RequestParam(name = "file") MultipartFile file);
+
+	@Operation(
+			summary = "업로드된 이미지 파일 presignurl 조회 API",
+			description =
+					"조회하고자 하는 이미지 파일의 이름(OriginalName - ex. cookie.jpeg) 을 입력해 이미지 파일의 presignUrl을 확인할 수 있는 API입니다. 존재하지 않는 파일을 업로드 해도 presignUrl이 나오지만 No Such element라는 xml이 표시될 것입니다.")
+	@ApiResponse(responseCode = "200")
+	ResponseEntity<String> getFile(@RequestParam(name = "fileName") String fileName);
+}

--- a/src/main/java/com/dife/api/controller/SwaggerFileController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerFileController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -36,4 +37,13 @@ public interface SwaggerFileController {
 					"조회하고자 하는 이미지 파일의 이름(OriginalName - ex. cookie.jpeg) 을 입력해 이미지 파일의 presignUrl을 확인할 수 있는 API입니다. 존재하지 않는 파일을 업로드 해도 presignUrl이 나오지만 No Such element라는 xml이 표시될 것입니다.")
 	@ApiResponse(responseCode = "200")
 	ResponseEntity<String> getFile(@RequestParam(name = "fileName") String fileName);
+
+	@Operation(
+			summary = "파일 삭제 API",
+			description = "사용자가 파일 고유 Id, 업로드 위치 타입을 입력해 Dife S3 Bucket에 파일을 삭제하는 API입니다.")
+	@ApiResponse(responseCode = "200")
+	ResponseEntity<Void> deleteFile(
+			@PathVariable(name = "id") Long id,
+			@RequestParam(name = "fileLocation") FileLocation fileLocation,
+			Authentication auth);
 }

--- a/src/main/java/com/dife/api/controller/SwaggerFileController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerFileController.java
@@ -1,35 +1,13 @@
 package com.dife.api.controller;
 
-import com.dife.api.model.FileLocation;
-import com.dife.api.model.dto.FileDto;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "File API", description = "파일 서비스 API")
 public interface SwaggerFileController {
-
-	@Operation(
-			summary = "파일 업로드 API",
-			description = "사용자가 파일 업로드 위치, 업로드 위치 id와 파일을 업로드 해 Dife S3 Bucket에 파일을 저장하는 API입니다.")
-	@ApiResponse(
-			responseCode = "200",
-			description = "파일 업로드 성공 예시",
-			content = {
-				@Content(mediaType = "application/json", schema = @Schema(implementation = FileDto.class))
-			})
-	ResponseEntity<FileDto> uploadFile(
-			@RequestParam(name = "fileLocation") FileLocation fileLocation,
-			@RequestParam(name = "id") Long id,
-			@RequestParam(name = "file") MultipartFile file,
-			Authentication auth);
 
 	@Operation(
 			summary = "업로드된 이미지 파일 presignurl 조회 API",
@@ -37,13 +15,4 @@ public interface SwaggerFileController {
 					"조회하고자 하는 이미지 파일의 이름(OriginalName - ex. cookie.jpeg) 을 입력해 이미지 파일의 presignUrl을 확인할 수 있는 API입니다. 존재하지 않는 파일을 업로드 해도 presignUrl이 나오지만 No Such element라는 xml이 표시될 것입니다.")
 	@ApiResponse(responseCode = "200")
 	ResponseEntity<String> getFile(@RequestParam(name = "fileName") String fileName);
-
-	@Operation(
-			summary = "파일 삭제 API",
-			description = "사용자가 파일 고유 Id, 업로드 위치 타입을 입력해 Dife S3 Bucket에 파일을 삭제하는 API입니다.")
-	@ApiResponse(responseCode = "200")
-	ResponseEntity<Void> deleteFile(
-			@PathVariable(name = "id") Long id,
-			@RequestParam(name = "fileLocation") FileLocation fileLocation,
-			Authentication auth);
 }

--- a/src/main/java/com/dife/api/controller/SwaggerFileController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerFileController.java
@@ -1,5 +1,6 @@
 package com.dife.api.controller;
 
+import com.dife.api.model.FileLocation;
 import com.dife.api.model.dto.FileDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -7,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,14 +17,18 @@ public interface SwaggerFileController {
 
 	@Operation(
 			summary = "파일 업로드 API",
-			description = "사용자가 파일을 업로드 해 Dife S3 Bucket에 파일을 저장하는 API입니다.")
+			description = "사용자가 파일 업로드 위치, 업로드 위치 id와 파일을 업로드 해 Dife S3 Bucket에 파일을 저장하는 API입니다.")
 	@ApiResponse(
 			responseCode = "200",
 			description = "파일 업로드 성공 예시",
 			content = {
 				@Content(mediaType = "application/json", schema = @Schema(implementation = FileDto.class))
 			})
-	ResponseEntity<FileDto> uploadFile(@RequestParam(name = "file") MultipartFile file);
+	ResponseEntity<FileDto> uploadFile(
+			@RequestParam(name = "fileLocation") FileLocation fileLocation,
+			@RequestParam(name = "id") Long id,
+			@RequestParam(name = "file") MultipartFile file,
+			Authentication auth);
 
 	@Operation(
 			summary = "업로드된 이미지 파일 presignurl 조회 API",

--- a/src/main/java/com/dife/api/controller/SwaggerMemberController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerMemberController.java
@@ -114,4 +114,8 @@ public interface SwaggerMemberController {
 	@ApiResponse(responseCode = "200")
 	ResponseEntity<List<MemberResponseDto>> getSearchMembers(
 			@RequestParam(name = "keyword") String keyword);
+
+	@Operation(summary = "회원이 작성한 게시글 조회 API", description = "회원의 인가를 이용해 작성한 게시글을 조회하는 API입니다.")
+	@ApiResponse(responseCode = "200")
+	ResponseEntity<List<PostResponseDto>> getMemberPosts(Authentication auth);
 }

--- a/src/main/java/com/dife/api/controller/SwaggerPostController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerPostController.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Post API", description = "게시판/게시글 서비스 API")
 public interface SwaggerPostController {
@@ -24,7 +25,13 @@ public interface SwaggerPostController {
 			responseCode = "201",
 			description = "게시글 생성 성공 예시",
 			content = @Content(mediaType = "application/json"))
-	ResponseEntity<PostResponseDto> createPost(PostCreateRequestDto requestDto, Authentication auth);
+	ResponseEntity<PostResponseDto> createPost(
+			@RequestParam(name = "title") String title,
+			@RequestParam(name = "content") String content,
+			@RequestParam(name = "isPublic") Boolean isPublic,
+			@RequestParam(name = "boardType") BoardCategory boardType,
+			@RequestParam(name = "postFile") MultipartFile postFile,
+			Authentication auth);
 
 	@Operation(summary = "단일 게시글 조회 API", description = "게시글 ID를 이용해 게시글을 가져옵니다.")
 	@ApiResponse(
@@ -49,7 +56,13 @@ public interface SwaggerPostController {
 						schema = @Schema(implementation = PostResponseDto.class))
 			})
 	ResponseEntity<PostResponseDto> updatePost(
-			@PathVariable(name = "id") Long id, PostUpdateRequestDto request, Authentication auth);
+			@PathVariable(name = "id") Long id,
+			@RequestParam(name = "title") String title,
+			@RequestParam(name = "content") String content,
+			@RequestParam(name = "isPublic") Boolean isPublic,
+			@RequestParam(name = "boardType") BoardCategory boardType,
+			@RequestParam(name = "postFile", required = false) MultipartFile postFile,
+			Authentication auth);
 
 	@Operation(summary = "게시글 삭제 API", description = "게시글 ID를 이용해 게시글을 삭제합니다.")
 	@ApiResponse(

--- a/src/main/java/com/dife/api/exception/FileUploadException.java
+++ b/src/main/java/com/dife/api/exception/FileUploadException.java
@@ -1,0 +1,7 @@
+package com.dife.api.exception;
+
+public class FileUploadException extends IllegalStateException {
+	public FileUploadException() {
+		super("파일 업로드 실패");
+	}
+}

--- a/src/main/java/com/dife/api/model/File.java
+++ b/src/main/java/com/dife/api/model/File.java
@@ -1,5 +1,6 @@
 package com.dife.api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -39,4 +40,9 @@ public class File {
 	@CreationTimestamp
 	@Column(name = "created_at", updatable = false, nullable = false)
 	private LocalDateTime createdAt;
+
+	@ManyToOne
+	@JoinColumn(name = "file_id")
+	@JsonIgnore
+	private Post post;
 }

--- a/src/main/java/com/dife/api/model/File.java
+++ b/src/main/java/com/dife/api/model/File.java
@@ -30,9 +30,6 @@ public class File {
 	@Column(nullable = false)
 	private Long size;
 
-	@Column(nullable = false)
-	private String url;
-
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private Format format;
@@ -42,7 +39,7 @@ public class File {
 	private LocalDateTime createdAt;
 
 	@ManyToOne
-	@JoinColumn(name = "file_id")
+	@JoinColumn(name = "post_id")
 	@JsonIgnore
 	private Post post;
 }

--- a/src/main/java/com/dife/api/model/FileLocation.java
+++ b/src/main/java/com/dife/api/model/FileLocation.java
@@ -1,0 +1,5 @@
+package com.dife.api.model;
+
+public enum FileLocation {
+	POST
+}

--- a/src/main/java/com/dife/api/model/Post.java
+++ b/src/main/java/com/dife/api/model/Post.java
@@ -2,6 +2,7 @@ package com.dife.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,9 +17,9 @@ public class Post extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	private String title;
+	private String title = "";
 
-	private String content;
+	private String content = "";
 
 	private Boolean isPublic = true;
 
@@ -43,7 +44,7 @@ public class Post extends BaseTimeEntity {
 	@JsonIgnore
 	private List<Bookmark> Bookmarks;
 
-	@OneToMany(mappedBy = "post", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+	@OneToMany(mappedBy = "post", fetch = FetchType.EAGER, cascade = CascadeType.MERGE)
 	@JsonIgnore
-	private List<File> files;
+	private List<File> files = new ArrayList<>();
 }

--- a/src/main/java/com/dife/api/model/Post.java
+++ b/src/main/java/com/dife/api/model/Post.java
@@ -42,4 +42,8 @@ public class Post extends BaseTimeEntity {
 	@OneToMany(mappedBy = "post", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
 	@JsonIgnore
 	private List<Bookmark> Bookmarks;
+
+	@OneToMany(mappedBy = "post", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+	@JsonIgnore
+	private List<File> files;
 }

--- a/src/main/java/com/dife/api/model/dto/FileDto.java
+++ b/src/main/java/com/dife/api/model/dto/FileDto.java
@@ -21,7 +21,7 @@ public class FileDto {
 
 	@NotNull private String size;
 
-	@NotNull private String url;
+	private String url;
 
 	@NotNull private Format format;
 

--- a/src/main/java/com/dife/api/model/dto/PostResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/PostResponseDto.java
@@ -1,7 +1,6 @@
 package com.dife.api.model.dto;
 
 import com.dife.api.model.BoardCategory;
-import com.dife.api.model.File;
 import com.dife.api.model.Member;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
@@ -34,7 +33,7 @@ public class PostResponseDto {
 
 	private LocalDateTime modified;
 
-	private List<File> files;
+	private List<FileDto> files;
 
 	@NotNull
 	@JsonProperty("writer")

--- a/src/main/java/com/dife/api/model/dto/PostResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/PostResponseDto.java
@@ -1,10 +1,12 @@
 package com.dife.api.model.dto;
 
 import com.dife.api.model.BoardCategory;
+import com.dife.api.model.File;
 import com.dife.api.model.Member;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.*;
 
 @Getter
@@ -31,6 +33,8 @@ public class PostResponseDto {
 	private LocalDateTime created;
 
 	private LocalDateTime modified;
+
+	private List<File> files;
 
 	@NotNull
 	@JsonProperty("writer")

--- a/src/main/java/com/dife/api/repository/PostRepository.java
+++ b/src/main/java/com/dife/api/repository/PostRepository.java
@@ -13,4 +13,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	List<Post> findPostsByBoardType(BoardCategory boardType, Sort sort);
 
 	Optional<Post> findByMemberAndId(@Param("member") Member member, @Param("postId") Long postId);
+
+	List<Post> findPostsByMember(Member member, Sort sort);
 }

--- a/src/main/java/com/dife/api/repository/PostRepository.java
+++ b/src/main/java/com/dife/api/repository/PostRepository.java
@@ -7,12 +7,11 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 	List<Post> findPostsByBoardType(BoardCategory boardType, Sort sort);
 
-	Optional<Post> findByMemberAndId(@Param("member") Member member, @Param("postId") Long postId);
+	Optional<Post> findByMemberAndId(Member member, Long id);
 
 	List<Post> findPostsByMember(Member member, Sort sort);
 }

--- a/src/main/java/com/dife/api/service/FileService.java
+++ b/src/main/java/com/dife/api/service/FileService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -105,5 +106,25 @@ public class FileService {
 		presigner.close();
 
 		return url;
+	}
+
+	public void deleteFileLocation(Long id, FileLocation fileLocation, String memberEmail) {
+		switch (fileLocation) {
+			case POST:
+				Post post = postService.checkPostMember(id, memberEmail);
+				postService.deletePostFile(post, id);
+				deleteFile(id);
+		}
+	}
+
+	public void deleteFile(Long id) {
+
+		File file = fileRepository.getReferenceById(id);
+		fileRepository.delete(file);
+
+		DeleteObjectRequest deleteObjectRequest =
+				DeleteObjectRequest.builder().bucket(bucketName).key(file.getOriginalName()).build();
+
+		s3Client.deleteObject(deleteObjectRequest);
 	}
 }

--- a/src/main/java/com/dife/api/service/FileService.java
+++ b/src/main/java/com/dife/api/service/FileService.java
@@ -1,7 +1,10 @@
 package com.dife.api.service;
 
+import com.dife.api.exception.FileUploadException;
 import com.dife.api.model.File;
+import com.dife.api.model.FileLocation;
 import com.dife.api.model.Format;
+import com.dife.api.model.Post;
 import com.dife.api.model.dto.FileDto;
 import com.dife.api.repository.FileRepository;
 import java.io.IOException;
@@ -29,8 +32,23 @@ public class FileService {
 	private final S3Presigner presigner;
 	private final ModelMapper modelMapper;
 
+	private final PostService postService;
+
 	@Value("${spring.aws.bucket-name}")
 	private String bucketName;
+
+	public FileDto uploadFileLocation(
+			MultipartFile file, FileLocation fileLocation, Long id, String memberEmail) {
+		switch (fileLocation) {
+			case POST:
+				Post post = postService.checkPostMember(id, memberEmail);
+				FileDto fileDto = upload(file);
+				postService.uploadPostFile(post, fileDto);
+				return fileDto;
+			default:
+				throw new FileUploadException();
+		}
+	}
 
 	public FileDto upload(MultipartFile file) {
 		if (file.isEmpty()) {

--- a/src/main/java/com/dife/api/service/FileService.java
+++ b/src/main/java/com/dife/api/service/FileService.java
@@ -1,10 +1,7 @@
 package com.dife.api.service;
 
-import com.dife.api.exception.FileUploadException;
 import com.dife.api.model.File;
-import com.dife.api.model.FileLocation;
 import com.dife.api.model.Format;
-import com.dife.api.model.Post;
 import com.dife.api.model.dto.FileDto;
 import com.dife.api.repository.FileRepository;
 import java.io.IOException;
@@ -33,23 +30,8 @@ public class FileService {
 	private final S3Presigner presigner;
 	private final ModelMapper modelMapper;
 
-	private final PostService postService;
-
 	@Value("${spring.aws.bucket-name}")
 	private String bucketName;
-
-	public FileDto uploadFileLocation(
-			MultipartFile file, FileLocation fileLocation, Long id, String memberEmail) {
-		switch (fileLocation) {
-			case POST:
-				Post post = postService.checkPostMember(id, memberEmail);
-				FileDto fileDto = upload(file);
-				postService.uploadPostFile(post, fileDto);
-				return fileDto;
-			default:
-				throw new FileUploadException();
-		}
-	}
 
 	public FileDto upload(MultipartFile file) {
 		if (file.isEmpty()) {
@@ -77,7 +59,6 @@ public class FileService {
 		fileInfo.setOriginalName(originalFilename);
 		fileInfo.setName(fileName);
 		fileInfo.setSize(fileSize);
-		fileInfo.setUrl("https://");
 		fileInfo.setFormat(Format.JPG);
 		fileRepository.save(fileInfo);
 
@@ -106,15 +87,6 @@ public class FileService {
 		presigner.close();
 
 		return url;
-	}
-
-	public void deleteFileLocation(Long id, FileLocation fileLocation, String memberEmail) {
-		switch (fileLocation) {
-			case POST:
-				Post post = postService.checkPostMember(id, memberEmail);
-				postService.deletePostFile(post, id);
-				deleteFile(id);
-		}
 	}
 
 	public void deleteFile(Long id) {

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.dife.api.service;
 
+import static java.util.stream.Collectors.toList;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import com.dife.api.config.RegisterValidator;
@@ -10,6 +11,7 @@ import com.dife.api.model.dto.*;
 import com.dife.api.repository.HobbyRepository;
 import com.dife.api.repository.LanguageRepository;
 import com.dife.api.repository.MemberRepository;
+import com.dife.api.repository.PostRepository;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -18,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -39,6 +42,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+	private final PostRepository postRepository;
 	private final LanguageRepository languageRepository;
 	private final HobbyRepository hobbyRepository;
 	private final BCryptPasswordEncoder passwordEncoder;
@@ -328,5 +332,15 @@ public class MemberService {
 							return responseDto;
 						})
 				.collect(Collectors.toList());
+	}
+
+	public List<PostResponseDto> getMemberPosts(String memberEmail) {
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
+
+		Sort sort = Sort.by(Sort.Direction.DESC, "created");
+		List<Post> posts = postRepository.findPostsByMember(member, sort);
+
+		return posts.stream().map(b -> modelMapper.map(b, PostResponseDto.class)).collect(toList());
 	}
 }

--- a/src/main/java/com/dife/api/service/PostService.java
+++ b/src/main/java/com/dife/api/service/PostService.java
@@ -9,6 +9,7 @@ import com.dife.api.model.File;
 import com.dife.api.model.Member;
 import com.dife.api.model.Post;
 import com.dife.api.model.dto.*;
+import com.dife.api.repository.FileRepository;
 import com.dife.api.repository.MemberRepository;
 import com.dife.api.repository.PostRepository;
 import java.util.List;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
 	private final PostRepository postRepository;
+	private final FileRepository fileRepository;
 	private final MemberRepository memberRepository;
 	private final ModelMapper modelMapper;
 
@@ -62,6 +64,12 @@ public class PostService {
 
 		post.getFiles().add(file);
 		postRepository.save(post);
+	}
+
+	public void deletePostFile(Post post, Long id) {
+		File file = fileRepository.getReferenceById(id);
+
+		post.getFiles().remove(file);
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
### 개요
- 파일 서비스를 이용해 기존의 파라미터 및 정보 DTO에 포함했어야 할 서비스를 분리해보았습니다.
- 적용한 코드가 서비스 독립적이라고 생각하는데 (기존의 코드는 파라미터로 다 받아야 해서 수고스럽다고 갑자기 생각이 들어서..!ㅎㅎ)
- 테스트 코드 작성완료 후에 팀원분들도 동의하신다면 해당 코드로 파일 서비스를 수정할 계획입니다!
- 본인글 조회 API는 엔드포인트를 찾아보니 /posts/me 혹은 /members/posts 두 가지로 많이들 사용하시는데 제 생각으로는 마이페이지에서 접근하는 API이므로 members에서 이어나가야 하지 않을까 싶었는데 혹시 더 좋은 엔드포인트가 있으시다면 알려주세요!!

#### 파일 업로드 게시글 테스트 방법
- 회원가입 -> 로그인 -> 파일 업로드 (POST 요청)-> 파일의 OriginalName (cookie.jpeg)로 파라미터를 넣음 (GET 요청) -> 이미지 파일의 presignUrl이 나옴
- 회원가입 -> 로그인 -> 게시글 작성 -> 본인 글 조회 엔드포인트 접근 (GET 요청)

#### 업로드 된 파일 수정
- 파일 수정은 파일 삭제와 동일함
- 회원가입 -> 로그인 -> 게시글 조회 (위의 테스트를 수행했다는 가정 하에) -> 파일 삭제 API (DELETE 요청) -> 게시글 조회 / presignURL 조회 (GET 요청)


#### 참고 (존재하지 않는 PresignUrl 조회 시)
<img width="906" alt="스크린샷 2024-06-29 오후 12 24 19" src="https://github.com/team-diverse/dife-backend/assets/124496650/c7f9f796-e81e-4608-bba4-e6035baff437">

