### PR TITLE
Refactor/bookmark postservice : 북마크 서비스에 댓글 추가 및 댓글 서비스 수정

### DIFF
--- a/src/main/java/com/dife/api/controller/BookmarkController.java
+++ b/src/main/java/com/dife/api/controller/BookmarkController.java
@@ -28,7 +28,7 @@ public class BookmarkController implements SwaggerBookmarkController {
 		return ResponseEntity.ok(bookmarks);
 	}
 
-	@PostMapping(consumes = "application/json")
+	@PostMapping
 	public ResponseEntity<BookmarkResponseDto> createBookmark(
 			@RequestBody BookmarkCreateRequestDto requestDto, Authentication auth) {
 		BookmarkResponseDto responseDto = bookmarkService.createBookmark(requestDto, auth.getName());

--- a/src/main/java/com/dife/api/controller/BookmarkController.java
+++ b/src/main/java/com/dife/api/controller/BookmarkController.java
@@ -1,6 +1,7 @@
 package com.dife.api.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
 
 import com.dife.api.model.dto.BookmarkCreateRequestDto;
 import com.dife.api.model.dto.BookmarkResponseDto;
@@ -40,5 +41,12 @@ public class BookmarkController implements SwaggerBookmarkController {
 		List<BookmarkResponseDto> bookmarks =
 				bookmarkService.getBookmarks(chatroomId, authentication.getName());
 		return ResponseEntity.ok(bookmarks);
+	}
+
+	@DeleteMapping
+	public ResponseEntity<Void> deleteBookmarkPost(
+			@RequestBody BookmarkCreateRequestDto requestDto, Authentication auth) {
+		bookmarkService.deleteBookmark(requestDto, auth.getName());
+		return new ResponseEntity<>(OK);
 	}
 }

--- a/src/main/java/com/dife/api/controller/ChatroomController.java
+++ b/src/main/java/com/dife/api/controller/ChatroomController.java
@@ -55,7 +55,7 @@ public class ChatroomController implements SwaggerChatroomController {
 		return ResponseEntity.status(CREATED).body(responseDto);
 	}
 
-	@PutMapping(value = "/{id}", consumes = "application/json")
+	@PutMapping("/{id}")
 	public ResponseEntity<ChatroomResponseDto> update(
 			@RequestBody GroupChatroomPutRequestDto requestDto,
 			@PathVariable(name = "id") Long chatroomId,

--- a/src/main/java/com/dife/api/controller/CommentController.java
+++ b/src/main/java/com/dife/api/controller/CommentController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController implements SwaggerCommentController {
 	private final CommentService commentService;
 
-	@PostMapping(consumes = "application/json")
+	@PostMapping
 	public ResponseEntity<CommentResponseDto> createComment(
 			@RequestBody CommentCreateRequestDto requestDto, Authentication auth) {
 

--- a/src/main/java/com/dife/api/controller/CommentController.java
+++ b/src/main/java/com/dife/api/controller/CommentController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController implements SwaggerCommentController {
 	private final CommentService commentService;
 
-	@PostMapping(value = "/{postId}", consumes = "application/json")
+	@PostMapping(consumes = "application/json")
 	public ResponseEntity<CommentResponseDto> createComment(
 			@RequestBody CommentCreateRequestDto requestDto, Authentication auth) {
 

--- a/src/main/java/com/dife/api/controller/ConnectController.java
+++ b/src/main/java/com/dife/api/controller/ConnectController.java
@@ -34,7 +34,7 @@ public class ConnectController implements SwaggerConnectController {
 		return ResponseEntity.status(OK).body(responseDto);
 	}
 
-	@PostMapping(value = "/", consumes = "application/json")
+	@PostMapping("/")
 	public ResponseEntity<ConnectResponseDto> createConnect(
 			@Valid @RequestBody ConnectRequestDto requestDto, Authentication auth) {
 		ConnectResponseDto responseDto = connectService.saveConnect(requestDto, auth.getName());

--- a/src/main/java/com/dife/api/controller/LikeController.java
+++ b/src/main/java/com/dife/api/controller/LikeController.java
@@ -24,7 +24,7 @@ public class LikeController implements SwaggerLikeController {
 		return ResponseEntity.status(OK).body(responseDto);
 	}
 
-	@PostMapping(consumes = "application/json")
+	@PostMapping
 	public ResponseEntity<Void> createLike(
 			@RequestBody LikeCreateRequestDto requestDto, Authentication auth) {
 

--- a/src/main/java/com/dife/api/controller/MemberController.java
+++ b/src/main/java/com/dife/api/controller/MemberController.java
@@ -29,7 +29,7 @@ public class MemberController implements SwaggerMemberController {
 	private final MemberService memberService;
 	private final JWTUtil jwtUtil;
 
-	@PostMapping(value = "/register", consumes = "application/json")
+	@PostMapping("/register")
 	public ResponseEntity<RegisterResponseDto> registerEmailAndPassword(
 			@Valid @RequestBody RegisterEmailAndPasswordRequestDto dto) {
 		RegisterResponseDto responseDto = memberService.registerEmailAndPassword(dto);
@@ -87,12 +87,12 @@ public class MemberController implements SwaggerMemberController {
 		return ResponseEntity.ok(responseDto);
 	}
 
-	@PostMapping(value = "/login", consumes = "application/json")
+	@PostMapping("/login")
 	public ResponseEntity<LoginSuccessDto> login(@Valid @RequestBody LoginDto dto) {
 		return memberService.login(dto);
 	}
 
-	@PostMapping(value = "/refresh-token", consumes = "application/json")
+	@PostMapping("/refresh-token")
 	public ResponseEntity<Void> checkToken(@Valid @RequestBody RefreshTokenRequestDto requestDto) {
 
 		boolean isTokenExpired = jwtUtil.isExpired(requestDto.getToken());

--- a/src/main/java/com/dife/api/controller/SwaggerBookmarkController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerBookmarkController.java
@@ -51,4 +51,8 @@ public interface SwaggerBookmarkController {
 			})
 	ResponseEntity<List<BookmarkResponseDto>> getBookmarkChats(
 			@PathVariable(name = "chatroomId") Long chatroomId, Authentication authentication);
+
+	@Operation(summary = "북마크 취소 API", description = "사용자가 DTO를 작성해 게시글/댓글 북마크를 취소하는 API입니다.")
+	@ApiResponse(responseCode = "200")
+	ResponseEntity<Void> deleteBookmarkPost(BookmarkCreateRequestDto requestDto, Authentication auth);
 }

--- a/src/main/java/com/dife/api/exception/DuplicateBookmarkException.java
+++ b/src/main/java/com/dife/api/exception/DuplicateBookmarkException.java
@@ -1,0 +1,8 @@
+package com.dife.api.exception;
+
+public class DuplicateBookmarkException extends DuplicateException {
+
+	public DuplicateBookmarkException() {
+		super("이미 북마크를 눌렀습니다!");
+	}
+}

--- a/src/main/java/com/dife/api/model/Bookmark.java
+++ b/src/main/java/com/dife/api/model/Bookmark.java
@@ -29,4 +29,8 @@ public class Bookmark {
 	@ManyToOne
 	@JoinColumn(name = "post_id")
 	private Post post;
+
+	@ManyToOne
+	@JoinColumn(name = "comment_id")
+	private Comment comment;
 }

--- a/src/main/java/com/dife/api/model/BookmarkType.java
+++ b/src/main/java/com/dife/api/model/BookmarkType.java
@@ -1,0 +1,7 @@
+package com.dife.api.model;
+
+public enum BookmarkType {
+	CHAT,
+	POST,
+	COMMENT
+}

--- a/src/main/java/com/dife/api/model/Comment.java
+++ b/src/main/java/com/dife/api/model/Comment.java
@@ -41,5 +41,10 @@ public class Comment extends BaseTimeEntity {
 	private List<Comment> childrenComments = new ArrayList<>();
 
 	@OneToMany(mappedBy = "comment", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+	@JsonIgnore
 	private List<LikeComment> CommentLikes;
+
+	@OneToMany(mappedBy = "comment", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+	@JsonIgnore
+	private List<Bookmark> Bookmarks;
 }

--- a/src/main/java/com/dife/api/model/dto/BookmarkCreateRequestDto.java
+++ b/src/main/java/com/dife/api/model/dto/BookmarkCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.dife.api.model.dto;
 
+import com.dife.api.model.BookmarkType;
 import lombok.*;
 
 @Getter
@@ -9,7 +10,9 @@ import lombok.*;
 @NoArgsConstructor
 public class BookmarkCreateRequestDto {
 
+	private BookmarkType type;
 	private Long chatroomId;
 	private Long chatId;
 	private Long postId;
+	private Long commentId;
 }

--- a/src/main/java/com/dife/api/model/dto/BookmarkResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/BookmarkResponseDto.java
@@ -1,5 +1,6 @@
 package com.dife.api.model.dto;
 
+import com.dife.api.model.Comment;
 import com.dife.api.model.Post;
 import lombok.*;
 
@@ -13,4 +14,5 @@ public class BookmarkResponseDto {
 	private Long id;
 	private String message;
 	private Post post;
+	private Comment comment;
 }

--- a/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
@@ -1,5 +1,6 @@
 package com.dife.api.model.dto;
 
+import com.dife.api.model.Comment;
 import com.dife.api.model.Member;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,7 +20,7 @@ public class CommentResponseDto {
 
 	private Boolean isPublic;
 
-	private Long parent_id;
+	private Comment parentComment;
 
 	private Integer likesCount;
 

--- a/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
@@ -1,11 +1,9 @@
 package com.dife.api.model.dto;
 
-import com.dife.api.model.Comment;
 import com.dife.api.model.Member;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.*;
 
 @Getter
@@ -21,12 +19,14 @@ public class CommentResponseDto {
 
 	private Boolean isPublic;
 
+	private Long parent_id;
+
 	private Integer likesCount;
+
+	private Integer bookmarkCount;
 
 	@JsonProperty("writer")
 	private Member writer;
-
-	private List<Comment> childrenComments;
 
 	@Schema(description = "프로필 생성 일시")
 	private LocalDateTime created;

--- a/src/main/java/com/dife/api/model/dto/PostResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/PostResponseDto.java
@@ -5,6 +5,7 @@ import com.dife.api.model.Member;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.*;
 
 @Getter

--- a/src/main/java/com/dife/api/model/dto/PostResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/PostResponseDto.java
@@ -1,6 +1,7 @@
 package com.dife.api.model.dto;
 
 import com.dife.api.model.BoardCategory;
+import com.dife.api.model.Comment;
 import com.dife.api.model.Member;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
@@ -38,4 +39,6 @@ public class PostResponseDto {
 	@NotNull
 	@JsonProperty("writer")
 	private Member Member;
+
+	private List<Comment> comments;
 }

--- a/src/main/java/com/dife/api/model/dto/PostResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/PostResponseDto.java
@@ -1,12 +1,10 @@
 package com.dife.api.model.dto;
 
 import com.dife.api.model.BoardCategory;
-import com.dife.api.model.Comment;
 import com.dife.api.model.Member;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.*;
 
 @Getter
@@ -39,6 +37,4 @@ public class PostResponseDto {
 	@NotNull
 	@JsonProperty("writer")
 	private Member Member;
-
-	private List<Comment> comments;
 }

--- a/src/main/java/com/dife/api/repository/BookmarkRepository.java
+++ b/src/main/java/com/dife/api/repository/BookmarkRepository.java
@@ -1,8 +1,11 @@
 package com.dife.api.repository;
 
 import com.dife.api.model.Bookmark;
+import com.dife.api.model.Comment;
 import com.dife.api.model.Member;
+import com.dife.api.model.Post;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +20,14 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 			@Param("chatroomId") Long chatroomId, @Param("member") Member member);
 
 	List<Bookmark> findAllByMember(Member member);
+
+	boolean existsBookmarkByPostAndMember(Post post, Member member);
+
+	Optional<Bookmark> findBookmarkByPostAndMember(Post post, Member member);
+
+	boolean existsBookmarkByCommentAndMember(Comment comment, Member member);
+
+	Optional<Bookmark> findBookmarkByCommentAndMember(Comment comment, Member member);
+
+	boolean existsBookmarkByMessage(@Param("message") String message);
 }

--- a/src/main/java/com/dife/api/service/BookmarkService.java
+++ b/src/main/java/com/dife/api/service/BookmarkService.java
@@ -24,6 +24,7 @@ public class BookmarkService {
 	private final ChatroomRepository chatroomRepository;
 	private final ChatRepository chatRepository;
 	private final PostRepository postRepository;
+	private final CommentRepository commentRepository;
 	private final MemberRepository memberRepository;
 	private final ModelMapper modelMapper;
 
@@ -80,6 +81,8 @@ public class BookmarkService {
 						.findByChatroomIdAndId(requestDto.getChatroomId(), requestDto.getChatId())
 						.orElseThrow(() -> new ChatroomException("유효하지 않은 채팅입니다!"));
 
+		if (bookmarkRepository.existsBookmarkByMessage(chat.getMessage()))
+			throw new DuplicateBookmarkException();
 		Bookmark bookmark = new Bookmark();
 		bookmark.setMessage(chat.getMessage());
 		bookmark.setMember(member);
@@ -96,6 +99,9 @@ public class BookmarkService {
 		Post post =
 				postRepository.findById(requestDto.getPostId()).orElseThrow(PostNotFoundException::new);
 		if (!post.getIsPublic()) throw new PostUnauthorizedException();
+
+		if (bookmarkRepository.existsBookmarkByPostAndMember(post, member))
+			throw new DuplicateBookmarkException();
 
 		Bookmark bookmark = new Bookmark();
 		bookmark.setPost(post);

--- a/src/main/java/com/dife/api/service/BookmarkService.java
+++ b/src/main/java/com/dife/api/service/BookmarkService.java
@@ -133,4 +133,39 @@ public class BookmarkService {
 		return modelMapper.map(bookmark, BookmarkResponseDto.class);
 	}
 
+	public void deleteBookmark(BookmarkCreateRequestDto requestDto, String memberEmail) {
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
+
+		switch (requestDto.getType()) {
+			case POST:
+				Post post =
+						postRepository.findById(requestDto.getPostId()).orElseThrow(PostNotFoundException::new);
+
+				Bookmark bookmarkPost =
+						bookmarkRepository
+								.findBookmarkByPostAndMember(post, member)
+								.orElseThrow(PostNotFoundException::new);
+
+				bookmarkPost.getPost().getBookmarks().remove(bookmarkPost);
+				member.getBookmarks().remove(bookmarkPost);
+				bookmarkRepository.delete(bookmarkPost);
+				break;
+
+			case COMMENT:
+				Comment comment =
+						commentRepository
+								.findById(requestDto.getCommentId())
+								.orElseThrow(CommentNotFoundException::new);
+
+				Bookmark bookmarkComment =
+						bookmarkRepository
+								.findBookmarkByCommentAndMember(comment, member)
+								.orElseThrow(LikeNotFoundException::new);
+
+				bookmarkComment.getComment().getBookmarks().remove(bookmarkComment);
+				bookmarkRepository.delete(bookmarkComment);
+				break;
+		}
+	}
 }

--- a/src/main/java/com/dife/api/service/CommentService.java
+++ b/src/main/java/com/dife/api/service/CommentService.java
@@ -10,8 +10,8 @@ import com.dife.api.model.dto.CommentResponseDto;
 import com.dife.api.repository.CommentRepository;
 import com.dife.api.repository.MemberRepository;
 import com.dife.api.repository.PostRepository;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -33,16 +33,8 @@ public class CommentService {
 	public List<CommentResponseDto> getCommentsByPostId(Long postId) {
 		Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
 		List<Comment> comments = commentRepository.findCommentsByPost(post);
-		Integer size = comments.size();
-		List<CommentResponseDto> dtoList = new ArrayList<>();
 
-		for (int i = 0; i < size; i++) {
-			Comment comment = comments.get(i);
-			CommentResponseDto responseDto = getComment(comment);
-			dtoList.add(responseDto);
-		}
-
-		return dtoList;
+		return comments.stream().map(this::getComment).collect(Collectors.toList());
 	}
 
 	public CommentResponseDto createComment(CommentCreateRequestDto requestDto, String memberEmail) {
@@ -69,7 +61,7 @@ public class CommentService {
 
 		CommentResponseDto responseDto = modelMapper.map(comment, CommentResponseDto.class);
 		if (comment.getParentComment() != null)
-			responseDto.setParent_id(comment.getParentComment().getId());
+			responseDto.setParentComment(comment.getParentComment());
 		return responseDto;
 	}
 
@@ -79,7 +71,7 @@ public class CommentService {
 		dto.setLikesCount(comment.getCommentLikes().size());
 		dto.setBookmarkCount(comment.getBookmarks().size());
 
-		if (comment.getParentComment() != null) dto.setParent_id(comment.getParentComment().getId());
+		if (comment.getParentComment() != null) dto.setParentComment(comment.getParentComment());
 
 		return dto;
 	}


### PR DESCRIPTION
### 개요
- 댓글/대댓글도 북마크를 누를 수 있게 함
- 북마크 중복 생성을 방지함
- 댓글 조회는 /comments/{postId} 로 함
- 대댓글은 DTO의 parent_id가 null이 아나며 최초 댓글이라면 parent_id가 null임으로 구별함
- 북마크 취소는 좋아요 취소방법과 동일함

#### 공지
- 모든 중복생성 익셉션은 409 conflict로 통일함
- 댓글은 게시글이 아닌 댓글 조회 엔티티에서 확인해야 함

#### 시나리오
1. 회원가입 -> 로그인 -> 게시글 생성 -> 댓글 생성 -> 대댓글 생성 후 댓글 조회 엔티티에서 확인
2. 회원가입 -> 로그인 -> 게시글 생성 -> 북마크 생성 -> 댓글 생성 -> 북마크 생성 -> 댓글 조회 엔티티에서 확인 (대댓글 북마크 생성도 동일)