### PR TITLE
fix(connect): 커넥트에서 Accept 안되는 부분 수정

### DIFF
--- a/src/main/java/com/dife/api/service/ConnectService.java
+++ b/src/main/java/com/dife/api/service/ConnectService.java
@@ -76,9 +76,6 @@ public class ConnectService {
 	}
 
 	public void acceptConnect(ConnectPatchRequestDto requestDto, String currentMemberEmail) {
-		if (!isConnectRelevant(requestDto.getMemberId(), currentMemberEmail)) {
-			throw new ConnectUnauthorizedException();
-		}
 		Member currentMember =
 				memberRepository.findByEmail(currentMemberEmail).orElseThrow(MemberNotFoundException::new);
 		Member otherMember =
@@ -100,8 +97,9 @@ public class ConnectService {
 		connectRepository.deleteById(id);
 	}
 
-	public boolean isConnectRelevant(Long id, String email) {
-		Connect connect = connectRepository.findById(id).orElseThrow(ConnectNotFoundException::new);
+	public boolean isConnectRelevant(Long connectId, String email) {
+		Connect connect =
+				connectRepository.findById(connectId).orElseThrow(ConnectNotFoundException::new);
 		String fromMemberEmail = connect.getFromMember().getEmail();
 		String toMemberEmail = connect.getToMember().getEmail();
 		return fromMemberEmail.equals(email) || toMemberEmail.equals(email);


### PR DESCRIPTION
### 개요

- connect에서 accept하는 patch request에서 Connect Not Found Exception이 발생한다.

### 원인

- connectId를 넘겨줘야하는데, memberId를 넘겨주고 있어서 에러가 나고 있었음

### 수정 사항

- connectId를 함수의 파라미터로 이름 명시하고, acceptConnect 함수에서 connectRepository에서 해당 커넥트가 없으면 에러를 리턴하므로, 불필요한
조건문을 삭제한다.