### PR TITLE
feat/member-comment-1: 회원이 작성한 댓글 조회 API 추가

### DIFF
--- a/src/main/java/com/dife/api/controller/MemberController.java
+++ b/src/main/java/com/dife/api/controller/MemberController.java
@@ -138,4 +138,10 @@ public class MemberController implements SwaggerMemberController {
 		List<PostResponseDto> responseDto = memberService.getMemberPosts(auth.getName());
 		return ResponseEntity.ok(responseDto);
 	}
+
+	@GetMapping("/comments")
+	public ResponseEntity<List<CommentResponseDto>> getMemberComments(Authentication auth) {
+		List<CommentResponseDto> responseDto = memberService.getComments(auth.getName());
+		return ResponseEntity.status(OK).body(responseDto);
+	}
 }

--- a/src/main/java/com/dife/api/controller/SwaggerMemberController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerMemberController.java
@@ -118,4 +118,8 @@ public interface SwaggerMemberController {
 	@Operation(summary = "회원이 작성한 게시글 조회 API", description = "회원의 인가를 이용해 작성한 게시글을 조회하는 API입니다.")
 	@ApiResponse(responseCode = "200")
 	ResponseEntity<List<PostResponseDto>> getMemberPosts(Authentication auth);
+
+	@Operation(summary = "회원이 작성한 댓글 조회 API", description = "회원의 인가를 이용해 작성한 댓글을 조회하는 API입니다.")
+	@ApiResponse(responseCode = "200")
+	ResponseEntity<List<CommentResponseDto>> getMemberComments(Authentication auth);
 }

--- a/src/main/java/com/dife/api/repository/CommentRepository.java
+++ b/src/main/java/com/dife/api/repository/CommentRepository.java
@@ -1,8 +1,10 @@
 package com.dife.api.repository;
 
 import com.dife.api.model.Comment;
+import com.dife.api.model.Member;
 import com.dife.api.model.Post;
 import java.util.List;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	List<Comment> findCommentsByPost(Post post);
+
+	List<Comment> findCommentsByWriter(Member writer, Sort sort);
 }

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -8,10 +8,7 @@ import com.dife.api.exception.*;
 import com.dife.api.jwt.JWTUtil;
 import com.dife.api.model.*;
 import com.dife.api.model.dto.*;
-import com.dife.api.repository.HobbyRepository;
-import com.dife.api.repository.LanguageRepository;
-import com.dife.api.repository.MemberRepository;
-import com.dife.api.repository.PostRepository;
+import com.dife.api.repository.*;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -43,6 +40,7 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 	private final PostRepository postRepository;
+	private final CommentRepository commentRepository;
 	private final LanguageRepository languageRepository;
 	private final HobbyRepository hobbyRepository;
 	private final BCryptPasswordEncoder passwordEncoder;
@@ -349,5 +347,17 @@ public class MemberService {
 		List<Post> posts = postRepository.findPostsByMember(member, sort);
 
 		return posts.stream().map(b -> modelMapper.map(b, PostResponseDto.class)).collect(toList());
+	}
+
+	public List<CommentResponseDto> getComments(String memberEmail) {
+		Member writer =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
+
+		Sort sort = Sort.by(Sort.Direction.DESC, "created");
+		List<Comment> comments = commentRepository.findCommentsByWriter(writer, sort);
+
+		return comments.stream()
+				.map(c -> modelMapper.map(c, CommentResponseDto.class))
+				.collect(toList());
 	}
 }


### PR DESCRIPTION
- 마이페이지 측 API에 조회 API 생성
- /members/comments GET 요청 시 회원이 작성한 댓글 조회 가능 
- 게시글과 동일하게 최신순 정렬 적용

검토 후에 최종본 코드일 때 은영님 Assign 하도록 하겠습니다! :)