### PR TITLE
Feat/dto isliked : 응답 DTO에 좋아요 누름 여부 표시

### DIFF
--- a/src/main/java/com/dife/api/controller/CommentController.java
+++ b/src/main/java/com/dife/api/controller/CommentController.java
@@ -28,8 +28,9 @@ public class CommentController implements SwaggerCommentController {
 
 	@GetMapping("/{postId}")
 	public ResponseEntity<List<CommentResponseDto>> getCommentsByPostId(
-			@PathVariable(name = "postId") Long postId) {
-		List<CommentResponseDto> responseDto = commentService.getCommentsByPostId(postId);
+			@PathVariable(name = "postId") Long postId, Authentication auth) {
+		List<CommentResponseDto> responseDto =
+				commentService.getCommentsByPostId(postId, auth.getName());
 		return ResponseEntity.status(OK).body(responseDto);
 	}
 }

--- a/src/main/java/com/dife/api/controller/PostController.java
+++ b/src/main/java/com/dife/api/controller/PostController.java
@@ -42,8 +42,9 @@ public class PostController implements SwaggerPostController {
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<PostResponseDto> getPost(@PathVariable(name = "id") Long id) {
-		PostResponseDto responseDto = postService.getPost(id);
+	public ResponseEntity<PostResponseDto> getPost(
+			@PathVariable(name = "id") Long id, Authentication auth) {
+		PostResponseDto responseDto = postService.getPost(id, auth.getName());
 		return ResponseEntity.status(OK).body(responseDto);
 	}
 

--- a/src/main/java/com/dife/api/controller/SwaggerCommentController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerCommentController.java
@@ -15,7 +15,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 @Tag(name = "Comment API", description = "댓글 서비스 API")
 public interface SwaggerCommentController {
 
-	@Operation(summary = "댓글 조회 API", description = "게시글 id를 입력해 속한 댓글을 조회하는 API입니다.")
+	@Operation(
+			summary = "댓글 조회 API",
+			description = "게시글 id를 입력해 속한 댓글을 조회하는 API입니다. 추가로 좋아요를 누른 댓글인지 여부도 표시됩니다.")
 	@ApiResponse(
 			responseCode = "200",
 			description = "단일 댓글 조회 예시",
@@ -25,7 +27,7 @@ public interface SwaggerCommentController {
 						schema = @Schema(implementation = CommentResponseDto.class))
 			})
 	ResponseEntity<List<CommentResponseDto>> getCommentsByPostId(
-			@PathVariable(name = "postId") Long postId);
+			@PathVariable(name = "postId") Long postId, Authentication auth);
 
 	@Operation(summary = "댓글 생성 API", description = "사용자가 DTO를 작성해 게시글에 대한 댓글을 생성하는 API입니다.")
 	@ApiResponse(

--- a/src/main/java/com/dife/api/controller/SwaggerPostController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerPostController.java
@@ -33,7 +33,9 @@ public interface SwaggerPostController {
 			@RequestParam(name = "postFile") MultipartFile postFile,
 			Authentication auth);
 
-	@Operation(summary = "단일 게시글 조회 API", description = "게시글 ID를 이용해 게시글을 가져옵니다.")
+	@Operation(
+			summary = "단일 게시글 조회 API",
+			description = "게시글 ID를 이용해 게시글을 가져옵니다. 추가로 좋아요를 누른 게시물인지 여부도 표시됩니다.")
 	@ApiResponse(
 			responseCode = "200",
 			description = "게시글 조회 성공 예시",
@@ -42,7 +44,7 @@ public interface SwaggerPostController {
 						mediaType = "application/json",
 						schema = @Schema(implementation = PostResponseDto.class))
 			})
-	ResponseEntity<PostResponseDto> getPost(@PathVariable(name = "id") Long id);
+	ResponseEntity<PostResponseDto> getPost(@PathVariable(name = "id") Long id, Authentication auth);
 
 	@Operation(
 			summary = "게시글 업데이트 API",

--- a/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
@@ -24,6 +24,8 @@ public class CommentResponseDto {
 
 	private Integer likesCount;
 
+	private Boolean isLiked;
+
 	private Integer bookmarkCount;
 
 	@JsonProperty("writer")

--- a/src/main/java/com/dife/api/model/dto/PostResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/PostResponseDto.java
@@ -27,6 +27,8 @@ public class PostResponseDto {
 
 	private Integer likesCount;
 
+	private Boolean isLiked = false;
+
 	private Integer bookmarkCount;
 
 	private LocalDateTime created;

--- a/src/main/java/com/dife/api/service/CommentService.java
+++ b/src/main/java/com/dife/api/service/CommentService.java
@@ -80,8 +80,8 @@ public class CommentService {
 
 		if (comment.getParentComment() != null) dto.setParentComment(comment.getParentComment());
 
-		if (likeCommentRepository.existsByCommentAndMember(comment, member)) dto.setIsLiked(true);
-		else dto.setIsLiked(false);
+		boolean isLiked = likeCommentRepository.existsByCommentAndMember(comment, member);
+		dto.setIsLiked(isLiked);
 
 		return dto;
 	}

--- a/src/main/java/com/dife/api/service/CommentService.java
+++ b/src/main/java/com/dife/api/service/CommentService.java
@@ -8,6 +8,7 @@ import com.dife.api.model.Post;
 import com.dife.api.model.dto.CommentCreateRequestDto;
 import com.dife.api.model.dto.CommentResponseDto;
 import com.dife.api.repository.CommentRepository;
+import com.dife.api.repository.LikeCommentRepository;
 import com.dife.api.repository.MemberRepository;
 import com.dife.api.repository.PostRepository;
 import java.util.List;
@@ -28,13 +29,19 @@ public class CommentService {
 	private final MemberRepository memberRepository;
 	private final ModelMapper modelMapper;
 	private final CommentRepository commentRepository;
+	private final LikeCommentRepository likeCommentRepository;
 
 	@Transactional(readOnly = true)
-	public List<CommentResponseDto> getCommentsByPostId(Long postId) {
+	public List<CommentResponseDto> getCommentsByPostId(Long postId, String memberEmail) {
 		Post post = postRepository.findById(postId).orElseThrow(PostNotFoundException::new);
+
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 		List<Comment> comments = commentRepository.findCommentsByPost(post);
 
-		return comments.stream().map(this::getComment).collect(Collectors.toList());
+		return comments.stream()
+				.map(comment -> getComment(comment, member))
+				.collect(Collectors.toList());
 	}
 
 	public CommentResponseDto createComment(CommentCreateRequestDto requestDto, String memberEmail) {
@@ -65,13 +72,16 @@ public class CommentService {
 		return responseDto;
 	}
 
-	public CommentResponseDto getComment(Comment comment) {
+	public CommentResponseDto getComment(Comment comment, Member member) {
 		CommentResponseDto dto = modelMapper.map(comment, CommentResponseDto.class);
 
 		dto.setLikesCount(comment.getCommentLikes().size());
 		dto.setBookmarkCount(comment.getBookmarks().size());
 
 		if (comment.getParentComment() != null) dto.setParentComment(comment.getParentComment());
+
+		if (likeCommentRepository.existsByCommentAndMember(comment, member)) dto.setIsLiked(true);
+		else dto.setIsLiked(false);
 
 		return dto;
 	}


### PR DESCRIPTION
#### 개요
- 기존의 좋아요와 게시글 사이에 있는 LikePost 엔티티를 이용해 좋아요 누름 여부를 판단 후에 responseDto에 
- isLiked 값을 갱신해주는 로직입니다.
- 게시글, 댓글 동일한 로직으로 작동합니다.

#### 테스트 방법
- 회원가입, 로그인 후 게시글 생성 -> 게시글 좋아요 POST 요청 (type과 postId or commentId 갱신 주의) -> 게시글 GET 요청
- 하면 응답 DTO에 isLiked값이 true로 바뀌어짐을 확인할 수 있습니다! :)
- 댓글 테스트도 동일한 방법으로 테스트합니다.


#### 응답예시
```
[
    {
        "id": 1,
        "content": "다른 댓글 내용2",
        "isPublic": true,
        "parentComment": null,
        "likesCount": 1,
        "isLiked": true,  
...
```