### PR TITLE
Feat/notification-expo-2

### DIFF
--- a/src/main/java/com/dife/api/controller/LikeController.java
+++ b/src/main/java/com/dife/api/controller/LikeController.java
@@ -1,5 +1,6 @@
 package com.dife.api.controller;
 
+import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 import com.dife.api.model.dto.LikeCreateRequestDto;
@@ -29,7 +30,7 @@ public class LikeController implements SwaggerLikeController {
 			@RequestBody LikeCreateRequestDto requestDto, Authentication auth) {
 
 		likeService.createLike(requestDto, auth.getName());
-		return new ResponseEntity<>(OK);
+		return new ResponseEntity<>(CREATED);
 	}
 
 	@DeleteMapping

--- a/src/main/java/com/dife/api/controller/NotificationController.java
+++ b/src/main/java/com/dife/api/controller/NotificationController.java
@@ -2,7 +2,6 @@ package com.dife.api.controller;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
-import com.dife.api.model.dto.NotificationRequestDto;
 import com.dife.api.model.dto.NotificationResponseDto;
 import com.dife.api.model.dto.NotificationTokenRequestDto;
 import com.dife.api.model.dto.NotificationTokenResponseDto;
@@ -40,14 +39,6 @@ public class NotificationController implements SwaggerNotificationController {
 			@RequestBody NotificationTokenRequestDto requestDto, Authentication auth) {
 		NotificationTokenResponseDto responseDto =
 				notificationService.sendNotificationToken(auth.getName(), requestDto);
-		return ResponseEntity.status(CREATED).body(responseDto);
-	}
-
-	@PostMapping("/send")
-	public ResponseEntity<NotificationResponseDto> createNotification(
-			@RequestBody NotificationRequestDto requestDto, Authentication auth) {
-		NotificationResponseDto responseDto =
-				notificationService.sendNotification(auth.getName(), requestDto);
 		return ResponseEntity.status(CREATED).body(responseDto);
 	}
 }

--- a/src/main/java/com/dife/api/controller/PostController.java
+++ b/src/main/java/com/dife/api/controller/PostController.java
@@ -28,7 +28,6 @@ public class PostController implements SwaggerPostController {
 
 	@PostMapping(consumes = "multipart/form-data")
 	public ResponseEntity<PostResponseDto> createPost(
-			@RequestParam(name = "tokenId") Long tokenId,
 			@RequestParam(name = "title") String title,
 			@RequestParam(name = "content") String content,
 			@RequestParam(name = "isPublic") Boolean isPublic,
@@ -37,8 +36,7 @@ public class PostController implements SwaggerPostController {
 			Authentication auth) {
 
 		PostResponseDto responseDto =
-				postService.createPost(
-						tokenId, title, content, isPublic, boardType, postFile, auth.getName());
+				postService.createPost(title, content, isPublic, boardType, postFile, auth.getName());
 
 		return ResponseEntity.status(CREATED).body(responseDto);
 	}

--- a/src/main/java/com/dife/api/controller/SwaggerNotificationController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerNotificationController.java
@@ -35,16 +35,4 @@ public interface SwaggerNotificationController {
 			})
 	ResponseEntity<NotificationTokenResponseDto> createNotificationToken(
 			NotificationTokenRequestDto requestDto, Authentication auth);
-
-	@Operation(summary = "알림 생성 API", description = "알림을 생성하는 API입니다.")
-	@ApiResponse(
-			responseCode = "201",
-			description = "알림 생성 성공 예시",
-			content = {
-				@Content(
-						mediaType = "application/json",
-						schema = @Schema(implementation = NotificationResponseDto.class))
-			})
-	ResponseEntity<NotificationResponseDto> createNotification(
-			NotificationRequestDto requestDto, Authentication auth);
 }

--- a/src/main/java/com/dife/api/controller/SwaggerPostController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerPostController.java
@@ -20,13 +20,15 @@ public interface SwaggerPostController {
 	@ApiResponse(responseCode = "200")
 	ResponseEntity<List<PostResponseDto>> getPostsByBoardType(BoardCategory boardCategory);
 
-	@Operation(summary = "게시글 생성 API", description = "DTO를 작성해 게시글을 생성합니다.")
+	@Operation(
+			summary = "게시글 생성 API",
+			description =
+					"DTO를 작성해 게시글을 생성합니다. \n 만약 알림 전송 문제가 있다는 500에러가 뜬다면 /notifications/push API를 통해 알림 토큰인 pushToken을 생성했는지 확인해주세요!")
 	@ApiResponse(
 			responseCode = "201",
 			description = "게시글 생성 성공 예시",
 			content = @Content(mediaType = "application/json"))
 	ResponseEntity<PostResponseDto> createPost(
-			@RequestParam(name = "tokenId") Long tokenId,
 			@RequestParam(name = "title") String title,
 			@RequestParam(name = "content") String content,
 			@RequestParam(name = "isPublic") Boolean isPublic,

--- a/src/main/java/com/dife/api/model/Member.java
+++ b/src/main/java/com/dife/api/model/Member.java
@@ -78,7 +78,7 @@ public class Member extends BaseTimeEntity {
 	@JsonIgnore
 	private Set<Bookmark> bookmarks;
 
-	@OneToMany(mappedBy = "member")
+	@OneToMany(mappedBy = "writer")
 	@JsonIgnore
 	private Set<Post> posts;
 

--- a/src/main/java/com/dife/api/model/Notification.java
+++ b/src/main/java/com/dife/api/model/Notification.java
@@ -17,6 +17,8 @@ public class Notification extends BaseTimeEntity {
 
 	private NotificationType type;
 
+	private String chatMemberEmail;
+
 	private String message;
 
 	private Boolean isRead = false;

--- a/src/main/java/com/dife/api/model/Notification.java
+++ b/src/main/java/com/dife/api/model/Notification.java
@@ -22,7 +22,7 @@ public class Notification extends BaseTimeEntity {
 	private Boolean isRead = false;
 
 	@ManyToOne
-	@JoinColumn(name = "notificationToken_id")
+	@JoinColumn(name = "notification_token_id")
 	@JsonIgnore
 	private NotificationToken notificationToken;
 }

--- a/src/main/java/com/dife/api/model/NotificationToken.java
+++ b/src/main/java/com/dife/api/model/NotificationToken.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Entity
-@Table(name = "notificationToken")
+@Table(name = "notification_token")
 public class NotificationToken extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/com/dife/api/model/NotificationType.java
+++ b/src/main/java/com/dife/api/model/NotificationType.java
@@ -1,6 +1,6 @@
 package com.dife.api.model;
 
 public enum NotificationType {
-	POST,
+	COMMUNITY,
 	CHAT
 }

--- a/src/main/java/com/dife/api/model/NotificationType.java
+++ b/src/main/java/com/dife/api/model/NotificationType.java
@@ -2,5 +2,6 @@ package com.dife.api.model;
 
 public enum NotificationType {
 	COMMUNITY,
+	CONNECT,
 	CHAT
 }

--- a/src/main/java/com/dife/api/model/Post.java
+++ b/src/main/java/com/dife/api/model/Post.java
@@ -28,7 +28,7 @@ public class Post extends BaseTimeEntity {
 
 	@ManyToOne
 	@JoinColumn(name = "member_id")
-	private Member member;
+	private Member writer;
 
 	@OneToMany(mappedBy = "post", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
 	@JsonIgnore

--- a/src/main/java/com/dife/api/model/dto/PostResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/PostResponseDto.java
@@ -39,5 +39,5 @@ public class PostResponseDto {
 
 	@NotNull
 	@JsonProperty("writer")
-	private Member Member;
+	private Member writer;
 }

--- a/src/main/java/com/dife/api/repository/PostRepository.java
+++ b/src/main/java/com/dife/api/repository/PostRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PostRepository extends JpaRepository<Post, Long> {
 	List<Post> findPostsByBoardType(BoardCategory boardType, Sort sort);
 
-	Optional<Post> findByMemberAndId(Member member, Long id);
+	Optional<Post> findByWriterAndId(Member writer, Long id);
 
-	List<Post> findPostsByMember(Member member, Sort sort);
+	List<Post> findPostsByWriter(Member writer, Sort sort);
 }

--- a/src/main/java/com/dife/api/service/ConnectService.java
+++ b/src/main/java/com/dife/api/service/ConnectService.java
@@ -3,9 +3,7 @@ package com.dife.api.service;
 import static java.util.stream.Collectors.toList;
 
 import com.dife.api.exception.*;
-import com.dife.api.model.Connect;
-import com.dife.api.model.ConnectStatus;
-import com.dife.api.model.Member;
+import com.dife.api.model.*;
 import com.dife.api.model.dto.ConnectPatchRequestDto;
 import com.dife.api.model.dto.ConnectRequestDto;
 import com.dife.api.model.dto.ConnectResponseDto;
@@ -72,6 +70,17 @@ public class ConnectService {
 		connect.setStatus(ConnectStatus.PENDING);
 		connectRepository.save(connect);
 
+		List<NotificationToken> notificationTokens = toMember.getNotificationTokens();
+
+		for (NotificationToken notificationToken : notificationTokens) {
+			Notification notification = new Notification();
+			notification.setNotificationToken(notificationToken);
+			notification.setType(NotificationType.CONNECT);
+			notification.setMessage("Hi!🤝 " + currentMember.getEmail() + "님이 회원님과의 커넥트를 맺고 싶어해요!");
+			notification.setIsRead(false);
+			notificationToken.getNotifications().add(notification);
+		}
+
 		return modelMapper.map(connect, ConnectResponseDto.class);
 	}
 
@@ -88,6 +97,10 @@ public class ConnectService {
 						.findByFromMemberAndToMember(otherMember, currentMember)
 						.orElseThrow(ConnectNotFoundException::new);
 		connect.setStatus(ConnectStatus.ACCEPTED);
+
+		createNotifications(currentMember, otherMember.getEmail());
+
+		createNotifications(otherMember, currentMember.getEmail());
 	}
 
 	public void deleteConnect(Long id, String email) {
@@ -117,5 +130,17 @@ public class ConnectService {
 				.findByFromMemberAndToMember(fromMember, toMember)
 				.map(connect -> connect.getStatus().equals(ConnectStatus.PENDING))
 				.orElse(false);
+	}
+
+	private void createNotifications(Member member, String otherMemberEmail) {
+		List<NotificationToken> notificationTokens = member.getNotificationTokens();
+		for (NotificationToken notificationToken : notificationTokens) {
+			Notification notification = new Notification();
+			notification.setNotificationToken(notificationToken);
+			notification.setType(NotificationType.CONNECT);
+			notification.setMessage("YEAH!🙌 " + otherMemberEmail + "님과의 커넥트가 성사되었어요!");
+			notification.setIsRead(false);
+			notificationToken.getNotifications().add(notification);
+		}
 	}
 }

--- a/src/main/java/com/dife/api/service/LikeService.java
+++ b/src/main/java/com/dife/api/service/LikeService.java
@@ -9,6 +9,7 @@ import com.dife.api.model.dto.LikeCreateRequestDto;
 import com.dife.api.model.dto.PostResponseDto;
 import com.dife.api.repository.*;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,6 +65,21 @@ public class LikeService {
 		postLike.setPost(post);
 		postLike.setMember(member);
 		likePostRepository.save(postLike);
+
+		Member writer = post.getWriter();
+
+		if (!Objects.equals(writer.getId(), member.getId())) {
+			List<NotificationToken> notificationTokens = writer.getNotificationTokens();
+
+			for (NotificationToken notificationToken : notificationTokens) {
+				Notification notification = new Notification();
+				notification.setNotificationToken(notificationToken);
+				notification.setType(NotificationType.COMMUNITY);
+				notification.setMessage("WOW!😆 " + member.getEmail() + "님이 회원님의 게시글을 좋아해요!");
+				notification.setIsRead(false);
+				notificationToken.getNotifications().add(notification);
+			}
+		}
 	}
 
 	public void deleteLikePost(LikeCreateRequestDto dto, String memberEmail) {
@@ -115,5 +131,20 @@ public class LikeService {
 		likeComment.setComment(comment);
 		likeComment.setMember(member);
 		likeCommentRepository.save(likeComment);
+
+		Member writer = comment.getWriter();
+
+		if (!Objects.equals(writer.getId(), member.getId())) {
+			List<NotificationToken> notificationTokens = writer.getNotificationTokens();
+
+			for (NotificationToken notificationToken : notificationTokens) {
+				Notification notification = new Notification();
+				notification.setNotificationToken(notificationToken);
+				notification.setType(NotificationType.COMMUNITY);
+				notification.setMessage("WOW!😆\n" + member.getEmail() + "님이 회원님의 댓글을 좋아해요!");
+				notification.setIsRead(false);
+				notificationToken.getNotifications().add(notification);
+			}
+		}
 	}
 }

--- a/src/main/java/com/dife/api/service/LikeService.java
+++ b/src/main/java/com/dife/api/service/LikeService.java
@@ -141,7 +141,7 @@ public class LikeService {
 				Notification notification = new Notification();
 				notification.setNotificationToken(notificationToken);
 				notification.setType(NotificationType.COMMUNITY);
-				notification.setMessage("WOW!😆\n" + member.getEmail() + "님이 회원님의 댓글을 좋아해요!");
+				notification.setMessage("WOW!😆 " + member.getEmail() + "님이 회원님의 댓글을 좋아해요!");
 				notification.setIsRead(false);
 				notificationToken.getNotifications().add(notification);
 			}

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -355,7 +355,7 @@ public class MemberService {
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 
 		Sort sort = Sort.by(Sort.Direction.DESC, "created");
-		List<Post> posts = postRepository.findPostsByMember(member, sort);
+		List<Post> posts = postRepository.findPostsByWriter(member, sort);
 
 		return posts.stream().map(b -> modelMapper.map(b, PostResponseDto.class)).collect(toList());
 	}

--- a/src/main/java/com/dife/api/service/NotificationService.java
+++ b/src/main/java/com/dife/api/service/NotificationService.java
@@ -56,9 +56,7 @@ public class NotificationService {
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 
 		NotificationToken notificationToken =
-				notificationTokenRepository
-						.findById(requestDto.getTokenId())
-						.orElseThrow(NotificationException::new);
+				notificationTokenRepository.findByMember(member).orElseThrow(NotificationException::new);
 
 		Notification notification = new Notification();
 		notification.setNotificationToken(notificationToken);

--- a/src/main/java/com/dife/api/service/NotificationService.java
+++ b/src/main/java/com/dife/api/service/NotificationService.java
@@ -3,11 +3,8 @@ package com.dife.api.service;
 import static java.util.stream.Collectors.toList;
 
 import com.dife.api.exception.MemberNotFoundException;
-import com.dife.api.exception.NotificationException;
 import com.dife.api.model.Member;
-import com.dife.api.model.Notification;
 import com.dife.api.model.NotificationToken;
-import com.dife.api.model.dto.NotificationRequestDto;
 import com.dife.api.model.dto.NotificationResponseDto;
 import com.dife.api.model.dto.NotificationTokenRequestDto;
 import com.dife.api.model.dto.NotificationTokenResponseDto;
@@ -47,28 +44,6 @@ public class NotificationService {
 		notificationTokenRepository.save(notificationToken);
 
 		return modelMapper.map(notificationToken, NotificationTokenResponseDto.class);
-	}
-
-	public NotificationResponseDto sendNotification(
-			String memberEmail, NotificationRequestDto requestDto) {
-
-		Member member =
-				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
-
-		NotificationToken notificationToken =
-				notificationTokenRepository.findByMember(member).orElseThrow(NotificationException::new);
-
-		Notification notification = new Notification();
-		notification.setNotificationToken(notificationToken);
-		notification.setType(requestDto.getType());
-		notification.setMessage(requestDto.getMessage());
-		notification.setIsRead(requestDto.getIsRead());
-
-		notificationToken.getNotifications().add(notification);
-
-		notificationTokenRepository.save(notificationToken);
-
-		return modelMapper.map(notification, NotificationResponseDto.class);
 	}
 
 	public List<NotificationTokenResponseDto> getNotificationTokens(String memberEmail) {

--- a/src/main/java/com/dife/api/service/PostService.java
+++ b/src/main/java/com/dife/api/service/PostService.java
@@ -59,7 +59,7 @@ public class PostService {
 		postRepository.save(post);
 
 		NotificationToken notificationToken =
-				notificationTokenRepository.findById(tokenId).orElseThrow(NotificationException::new);
+				notificationTokenRepository.findByMember(member).orElseThrow(NotificationException::new);
 
 		Notification notification = new Notification();
 		notification.setType(NotificationType.POST);

--- a/src/main/java/com/dife/api/service/PostService.java
+++ b/src/main/java/com/dife/api/service/PostService.java
@@ -3,14 +3,12 @@ package com.dife.api.service;
 import static java.util.stream.Collectors.toList;
 
 import com.dife.api.exception.MemberNotFoundException;
-import com.dife.api.exception.NotificationException;
 import com.dife.api.exception.PostNotFoundException;
 import com.dife.api.model.*;
 import com.dife.api.model.dto.*;
 import com.dife.api.repository.FileRepository;
 import com.dife.api.repository.LikePostRepository;
 import com.dife.api.repository.MemberRepository;
-import com.dife.api.repository.NotificationTokenRepository;
 import com.dife.api.repository.PostRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -34,11 +32,8 @@ public class PostService {
 	private final FileRepository fileRepository;
 	private final MemberRepository memberRepository;
 	private final ModelMapper modelMapper;
-	private final NotificationService notificationService;
-	private final NotificationTokenRepository notificationTokenRepository;
 
 	public PostResponseDto createPost(
-			Long tokenId,
 			String title,
 			String content,
 			Boolean isPublic,
@@ -54,20 +49,9 @@ public class PostService {
 		post.setContent(content);
 		post.setIsPublic(isPublic);
 		post.setBoardType(boardType);
-		post.setMember(member);
+		post.setWriter(member);
 
 		postRepository.save(post);
-
-		NotificationToken notificationToken =
-				notificationTokenRepository.findByMember(member).orElseThrow(NotificationException::new);
-
-		Notification notification = new Notification();
-		notification.setType(NotificationType.POST);
-		notification.setMessage("NEW POST IS CREATED!");
-		notification.setNotificationToken(notificationToken);
-
-		NotificationRequestDto requestDto = modelMapper.map(notification, NotificationRequestDto.class);
-		notificationService.sendNotification(memberEmail, requestDto);
 
 		if (!postFile.isEmpty()) {
 			FileDto fileDto = fileService.upload(postFile);
@@ -135,7 +119,7 @@ public class PostService {
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 
 		Post post =
-				postRepository.findByMemberAndId(member, id).orElseThrow(PostNotFoundException::new);
+				postRepository.findByWriterAndId(member, id).orElseThrow(PostNotFoundException::new);
 
 		post.setTitle((title != null && !title.isEmpty()) ? title : post.getTitle());
 		post.setContent((content != null && !content.isEmpty()) ? content : post.getContent());
@@ -165,7 +149,7 @@ public class PostService {
 		Member member =
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 		Post post =
-				postRepository.findByMemberAndId(member, id).orElseThrow(PostNotFoundException::new);
+				postRepository.findByWriterAndId(member, id).orElseThrow(PostNotFoundException::new);
 
 		for (File file : post.getFiles()) {
 			fileService.deleteFile(file.getId());


### PR DESCRIPTION
#### 개요
- #169 의 피드백 반영 및 서버 자동 알림 구현 예시 PR입니다.

예시는 

> 커뮤니티 서비스
> 본인이 작성한 게시글/댓글에 댓글/좋아요 달렸을 경우
- 알림은 좋아요 생성과 다르게 본인이 좋아요를 눌렀을 때에는 알림이 가지 않도록 함.

> 채팅서비스
> 채팅이 왔을 경우
> 본인이 속한 그룹 채팅방에 다른 회원이 입장했을 경우
- 알림은 본인의 채팅 / 본인의 입장의 경우 본인의 알림에는 포함되지 않음

> 커넥트 서비스
> 커넥트 요청왔을 경우
> 커넥트 성공 시
- 알림은 본인의 커넥트 요청은 포함되지 않음 / 커넥트 성공은 모두에게 표시됨

- 작성자의 모든 기기에 알림이 가도록 구현했습니다.
- 외에 검토 중에 발생한 오류 사항을 반영해두었습니다!


--- 
### 테스트 방법

`사용자마다 /notifications/push API로 알림 토큰 생성을 잊지 말아주세용`

#### 게시글/댓글 좋아요 알림
- 알림 생성 X : 회원가입, 로그인 -> /notifications/push로 알림 토큰 생성 -> 게시글 생성 -> 본인이 작성한 게시글에 좋아요 생성
- 알림 생성 O : 회원가입, 로그인 -> 위에 만들어 놓은 게시글에 좋아요 생성

#### 커넥트 알림
- 두 개의 계정 생성 -> 각각의 계정 알림 토큰 생성 -> 커넥트 생성 (POST) / 커넥트 수락 (PATCH)

#### 채팅방 알림
- 채팅방 입장 : 두 개의 계정 생성 -> 각각의 계정 알림 토큰 생성 -> 한 개의 계정에서 채팅방 생성 -> APIC tester로 나머지 한 계정으로 입장
- 채팅 생성 : 나머지 한 계정으로 채팅 생성


`후 /notifications GET API에서 생성된 알림들을 확인할 수 있습니다.`