### PR TITLE
Fix/community: 프론트에서 필요한 커뮤니티 정보를 응답 DTO에 추가

### DIFF
--- a/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
@@ -2,6 +2,7 @@ package com.dife.api.model.dto;
 
 import com.dife.api.model.Comment;
 import com.dife.api.model.Member;
+import com.dife.api.model.Post;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -20,11 +21,13 @@ public class CommentResponseDto {
 
 	private Boolean isPublic;
 
+	private Boolean isLiked;
+
+	private Post post;
+
 	private Comment parentComment;
 
 	private Integer likesCount;
-
-	private Boolean isLiked;
 
 	private Integer bookmarkCount;
 

--- a/src/main/java/com/dife/api/model/dto/PostResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/PostResponseDto.java
@@ -23,11 +23,13 @@ public class PostResponseDto {
 
 	private BoardCategory boardType;
 
-	private Boolean isPublic;
-
-	private Integer likesCount;
+	private Boolean isPublic = true;
 
 	private Boolean isLiked = false;
+
+	private Integer commentCount;
+
+	private Integer likesCount;
 
 	private Integer bookmarkCount;
 

--- a/src/main/java/com/dife/api/service/CommentService.java
+++ b/src/main/java/com/dife/api/service/CommentService.java
@@ -75,6 +75,7 @@ public class CommentService {
 	public CommentResponseDto getComment(Comment comment, Member member) {
 		CommentResponseDto dto = modelMapper.map(comment, CommentResponseDto.class);
 
+		dto.setPost(comment.getPost());
 		dto.setLikesCount(comment.getCommentLikes().size());
 		dto.setBookmarkCount(comment.getBookmarks().size());
 

--- a/src/main/java/com/dife/api/service/PostService.java
+++ b/src/main/java/com/dife/api/service/PostService.java
@@ -72,7 +72,16 @@ public class PostService {
 		Sort sort = Sort.by(Sort.Direction.DESC, "created");
 		List<Post> posts = postRepository.findPostsByBoardType(boardCategory, sort);
 
-		return posts.stream().map(b -> modelMapper.map(b, PostResponseDto.class)).collect(toList());
+		return posts.stream()
+				.map(
+						post -> {
+							PostResponseDto responseDto = modelMapper.map(post, PostResponseDto.class);
+							responseDto.setCommentCount(post.getComments().size());
+							responseDto.setLikesCount(post.getPostLikes().size());
+							responseDto.setBookmarkCount(post.getBookmarks().size());
+							return responseDto;
+						})
+				.collect(toList());
 	}
 
 	@Transactional(readOnly = true)
@@ -83,6 +92,7 @@ public class PostService {
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 
 		PostResponseDto responseDto = modelMapper.map(post, PostResponseDto.class);
+		responseDto.setCommentCount(post.getComments().size());
 		responseDto.setLikesCount(post.getPostLikes().size());
 		responseDto.setBookmarkCount(post.getBookmarks().size());
 


### PR DESCRIPTION
#### 개요
- 프론트에서 필요한 커뮤니티 정보를 응답 DTO에 추가한 PR입니다!

1. 게시글 조회 시 댓글 갯수 표시
2. 댓글 조회 시 종속되어 있는 게시글 정보 포함

### 테스트 방법
- 회원가입, 로그인 후 게시글 생성 -> 댓글 생성 -> 대댓글 생성

응답 예시

> 게시글 조회 시 (/posts/{postId} - GET)
```
{
    "id": 3,
    "title": "제목3",
    "content": "내용",
    "boardType": "FREE",
    "isPublic": true,
    "isLiked": false,
    "commentCount": 1,
...
```

> 댓글 생성 시 (/comments - POST, /comments/{postId} - GET)

> 댓글

```
{
    "id": 2,
    "content": "다른 댓글 내용2",
    "isPublic": true,
    "isLiked": null,
    "post": {
        "created": "2024-08-02T04:14:23.187793",
        "modified": "2024-08-02T04:14:23.187793",
        "id": 4,
...
```

> 대댓글

```
{
        "id": 3,
        "content": "다른 댓글 내용",
        "isPublic": true,
        "isLiked": false,
        "post": {
            "created": "2024-08-02T04:14:23.187793",
            "modified": "2024-08-02T04:14:23.187793",
            "id": 4,

...

    "parentComment": {
            "created": "2024-08-02T04:14:38.854485",
            "modified": "2024-08-02T04:14:38.854485",
            "id": 2,
```