### PR TITLE
fix/notificationToken-byDeviceId-1: DeviceId마다 알림 리스트를 GET할 수 있도록

### DIFF
--- a/src/main/java/com/dife/api/controller/NotificationController.java
+++ b/src/main/java/com/dife/api/controller/NotificationController.java
@@ -28,10 +28,11 @@ public class NotificationController implements SwaggerNotificationController {
 		return ResponseEntity.ok(responseDtos);
 	}
 
-	@GetMapping
-	public ResponseEntity<List<NotificationResponseDto>> getNotifications(Authentication auth) {
+	@GetMapping("/{deviceId}")
+	public ResponseEntity<List<NotificationResponseDto>> getNotifications(
+			@PathVariable("deviceId") String deviceId, Authentication auth) {
 		List<NotificationResponseDto> responseDtos =
-				notificationService.getNotifications(auth.getName());
+				notificationService.getNotifications(deviceId, auth.getName());
 		return ResponseEntity.ok(responseDtos);
 	}
 

--- a/src/main/java/com/dife/api/controller/SwaggerNotificationController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerNotificationController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Notification API", description = "알림 서비스 API")
 public interface SwaggerNotificationController {
@@ -22,7 +23,8 @@ public interface SwaggerNotificationController {
 						mediaType = "application/json",
 						schema = @Schema(implementation = NotificationResponseDto.class))
 			})
-	ResponseEntity<List<NotificationResponseDto>> getNotifications(Authentication auth);
+	ResponseEntity<List<NotificationResponseDto>> getNotifications(
+			@PathVariable("deviceId") String deviceId, Authentication auth);
 
 	@Operation(summary = "알림 토큰 생성 API", description = "사용자의 접속 기기에 따른 알림 토큰을 생성하는 API입니다.")
 	@ApiResponse(

--- a/src/main/java/com/dife/api/repository/NotificationTokenRepository.java
+++ b/src/main/java/com/dife/api/repository/NotificationTokenRepository.java
@@ -3,11 +3,18 @@ package com.dife.api.repository;
 import com.dife.api.model.Member;
 import com.dife.api.model.NotificationToken;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotificationTokenRepository extends JpaRepository<NotificationToken, Long> {
 
+	Optional<NotificationToken> findAllByMemberAndDeviceId(Member member, String deviceId);
+
 	List<NotificationToken> findAllByMember(Member member);
+
+	boolean existsByDeviceId(String deviceId);
+
+	Optional<NotificationToken> findByDeviceId(String deviceId);
 }

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -58,15 +58,15 @@ INSERT INTO hobby(ID, MEMBER_ID, NAME)
 VALUES ('4', '5', 'SOCCER');
 
 INSERT INTO notification_token(ID, MEMBER_ID, DEVICE_ID, PUSH_TOKEN)
-VALUES ('1', '1', 'XXXX-XXXX-XXXX', 'pushToken1');
+VALUES ('1', '1', 'deviceId1', 'pushToken1');
 INSERT INTO notification_token(ID, MEMBER_ID, DEVICE_ID, PUSH_TOKEN)
-VALUES ('2', '2', 'XXXX-XXXX-XXXX', 'pushToken2');
+VALUES ('2', '2', 'deviceId2', 'pushToken2');
 INSERT INTO notification_token(ID, MEMBER_ID, DEVICE_ID, PUSH_TOKEN)
-VALUES ('3', '3', 'XXXX-XXXX-XXXX', 'pushToken3');
+VALUES ('3', '3', 'deviceId3', 'pushToken3');
 INSERT INTO notification_token(ID, MEMBER_ID, DEVICE_ID, PUSH_TOKEN)
-VALUES ('4', '4', 'XXXX-XXXX-XXXX', 'pushToken4');
+VALUES ('4', '4', 'deviceId4', 'pushToken4');
 INSERT INTO notification_token(ID, MEMBER_ID, DEVICE_ID, PUSH_TOKEN)
-VALUES ('5', '5', 'XXXX-XXXX-XXXX', 'pushToken5');
+VALUES ('5', '5', 'deviceId5', 'pushToken5');
 
 ALTER TABLE post MODIFY COLUMN content LONGTEXT;
 


### PR DESCRIPTION
#### 로직 

```
- NotificationController, getNotifications:
- 알림 리스트를 받아올 때 pathVariable에 deviceId 추가해 deviceId별 알림 리스트를 받아올 수 있도록 함
- 이때 deviceId를 가진 회원만이 알림들을 가져올 수 있음

- sendNotificationTokens:
- deviceId 마다 하나의 토큰만이 생성되도록 로직 수정
- isTokenAlive 메서드를 추가해 이전에 해당 device 앞으로 된 토큰이 있는지 확인하고 없다면 새로 만들고
- 기존에 회원이 등록했던 deviceIdfh 된 토큰이라면 새로 만들지 않고 응답 DTO를 작성함
```

#### 시나리오

1. 같은 유저 각 DeviceId마다 알림 1개 생성 

```
1. 5번 유저로 로그인
2. deviceId6으로 POST :/notifications/push
3. 본인 계정으로 로그인
4. 토큰으로 1번 게시글(작성자 : gusuyeon@gmail.com)에 대해 댓글 생성 (POST :/comments)
5. GET :/notifications/deviceId5 해서 댓글 생성 알림 1개 온 것 확인
6. GET :/notifications/deviceId6 해서 댓글 생성 알림 1개 온 것 확인
```

2. 다른 유저 로그인 시 새로운 DeviceId 쟁취

```
1. 본인 계정으로 로그인 및 게시글 작성(POST)
2. POST :/notifications/push 에서 5번 유저의 deviceId 쟁취 
{
    "pushToken" : "pushToken",
    "deviceId" : "deviceId5"
}
3. 5번 계정으로 로그인 해 본인 계정이 작성한 글로 댓글 생성
4. 본인 계정으로 로그인 해 GET :/notifications/deviceId5 하면 5번 유저가 아닌 본인 계정으로 알림이 들어오는 것을 알 수 있다.

(Token이 로그인 될 때마다 새로 생성되기 때문에 생성될 때마다 프론트에서 모든 엔드포인트에서 Token을 갈아줌 가정)
```