### PR TITLE
feat/chatroom-random-1: 랜덤하게 10개 그룹 채팅방 뽑아오는 API 추가 및 탈퇴 시 댓글 삭제 처리 로직 수정

### DIFF
--- a/src/main/java/com/dife/api/controller/ChatroomController.java
+++ b/src/main/java/com/dife/api/controller/ChatroomController.java
@@ -148,4 +148,12 @@ public class ChatroomController {
 		List<ChatroomResponseDto> responseDto = chatroomService.getLikedChatrooms(auth.getName());
 		return ResponseEntity.ok(responseDto);
 	}
+
+	@GetMapping("/random")
+	public ResponseEntity<List<ChatroomResponseDto>> getRandomChatrooms(
+			@RequestParam(name = "count", defaultValue = "1") int count, Authentication auth) {
+		List<ChatroomResponseDto> responseDto =
+				chatroomService.getRandomChatrooms(count, auth.getName());
+		return ResponseEntity.ok(responseDto);
+	}
 }

--- a/src/main/java/com/dife/api/controller/SwaggerChatroomController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerChatroomController.java
@@ -147,4 +147,11 @@ public interface SwaggerChatroomController {
 						schema = @Schema(implementation = ChatroomResponseDto.class))
 			})
 	ResponseEntity<List<ChatroomResponseDto>> getLikeChatrooms(Authentication auth);
+
+	@Operation(
+			summary = "홈화면 랜덤 10개 채팅방 조회 API",
+			description = "홈화면에 보일 커넥트 준비상태 10개 회원 정보를 확인할 수 있습니다.")
+	@ApiResponse(responseCode = "200")
+	ResponseEntity<List<ChatroomResponseDto>> getRandomChatrooms(
+			@RequestParam(name = "count", defaultValue = "1") int count, Authentication auth);
 }

--- a/src/main/java/com/dife/api/model/Comment.java
+++ b/src/main/java/com/dife/api/model/Comment.java
@@ -31,12 +31,12 @@ public class Comment extends BaseTimeEntity {
 	@JsonIgnore
 	private Post post;
 
-	@ManyToOne(cascade = CascadeType.ALL)
+	@ManyToOne
 	@JoinColumn(name = "parent_id")
 	@JsonIgnore
 	private Comment parentComment;
 
-	@OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL)
+	@OneToMany(mappedBy = "parentComment")
 	@JsonBackReference
 	private List<Comment> childrenComments = new ArrayList<>();
 

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -490,6 +490,7 @@ public class ChatroomService {
 		List<Chatroom> randomChatrooms =
 				chatroomRepository.findAll().stream()
 						.filter(c -> c.getChatroomType() == ChatroomType.GROUP)
+						.filter(c -> !c.getManager().getId().equals(member.getId()))
 						.filter(c -> c.getChatroomSetting().getMaxCount() > c.getMembers().size())
 						.collect(toList());
 

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -484,6 +484,26 @@ public class ChatroomService {
 				.collect(Collectors.toList());
 	}
 
+	public List<ChatroomResponseDto> getRandomChatrooms(int count, String email) {
+		Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
+
+		List<Chatroom> randomChatrooms =
+				chatroomRepository.findAll().stream()
+						.filter(c -> c.getChatroomType() == ChatroomType.GROUP)
+						.filter(c -> c.getChatroomSetting().getMaxCount() > c.getMembers().size())
+						.collect(toList());
+
+		log.info(String.valueOf(randomChatrooms.size()));
+		if (randomChatrooms.isEmpty()) {
+			return new ArrayList<>();
+		}
+
+		Collections.shuffle(randomChatrooms);
+		List<Chatroom> chatrooms = randomChatrooms.stream().limit(count).toList();
+
+		return getChatroomResponseDtos(chatrooms, member);
+	}
+
 	public void kickout(Long roomId, Long memberId, String memberEmail) {
 		Chatroom chatroom =
 				chatroomRepository.findById(roomId).orElseThrow(ChatroomNotFoundException::new);

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -380,8 +380,12 @@ public class MemberService {
 		List<Comment> comments = commentRepository.findAllByWriter(member);
 
 		for (Comment comment : comments) {
-			if (comment != null) {
+			if (comment.getChildrenComments() == null || comment.getChildrenComments().isEmpty()) {
+				comment.getPost().getComments().remove(comment);
+				commentRepository.delete(comment);
+			} else if (comment.getChildrenComments() != null || comment.getParentComment() != null) {
 				comment.setWriter(null);
+				comment.setContent(null);
 				commentRepository.save(comment);
 			}
 		}


### PR DESCRIPTION

구현사항
```
- 승호님의 기존 random 메서드 shuffle 화 재활용
- 나머지 로직은 다른 필터링 로직과 동일
- 랜덤한 채팅방 10개의 후보군으로는 그룹 채팅방, 인원수가 꽉 차지 않은 채팅방이 보여짐
```

추가 사항 (탈퇴 시 댓글 삭제 처리)

```
- 솔로 댓글일 경우 -> 탈퇴 시 자동 삭제
- 자식 댓글일 경우 -> 탈퇴 시 자동 삭제
- 부모 댓글일 경우 -> 탈퇴 시 NULL 처리
```