### PR TITLE
refactor(file): File 모델의 URL 컬럼 삭제, Exception 리팩토링

### DIFF
--- a/src/main/java/com/dife/api/GlobalExceptionHandler.java
+++ b/src/main/java/com/dife/api/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.dife.api;
 import static org.springframework.http.HttpStatus.*;
 
 import com.dife.api.exception.*;
+import com.dife.api.exception.file.S3FileNameInvalidException;
+import com.dife.api.exception.file.S3FileNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -124,6 +126,20 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	@ExceptionHandler(RuntimeException.class)
 	public ResponseEntity<ExceptionResonse> handleRuntimeException(RuntimeException exception) {
 		return ResponseEntity.status(FORBIDDEN.value())
+				.body(new ExceptionResonse(false, exception.getMessage()));
+	}
+
+	@ExceptionHandler(S3FileNotFoundException.class)
+	public ResponseEntity<ExceptionResonse> handleS3FileNotFoundException(
+			S3FileNotFoundException exception) {
+		return ResponseEntity.status(NOT_FOUND.value())
+				.body(new ExceptionResonse(false, exception.getMessage()));
+	}
+
+	@ExceptionHandler(S3FileNameInvalidException.class)
+	public ResponseEntity<ExceptionResonse> handleS3FileNameInvalidException(
+			S3FileNameInvalidException exception) {
+		return ResponseEntity.status(BAD_REQUEST.value())
 				.body(new ExceptionResonse(false, exception.getMessage()));
 	}
 }

--- a/src/main/java/com/dife/api/exception/file/S3FileNameInvalidException.java
+++ b/src/main/java/com/dife/api/exception/file/S3FileNameInvalidException.java
@@ -1,0 +1,7 @@
+package com.dife.api.exception.file;
+
+public class S3FileNameInvalidException extends RuntimeException {
+	public S3FileNameInvalidException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/dife/api/exception/file/S3FileNotFoundException.java
+++ b/src/main/java/com/dife/api/exception/file/S3FileNotFoundException.java
@@ -1,0 +1,7 @@
+package com.dife.api.exception.file;
+
+public class S3FileNotFoundException extends RuntimeException {
+	public S3FileNotFoundException() {
+		super("해당 파일은 존재하지 않습니다.");
+	}
+}

--- a/src/main/java/com/dife/api/model/File.java
+++ b/src/main/java/com/dife/api/model/File.java
@@ -23,9 +23,6 @@ public class File extends BaseTimeEntity {
 
 	private String name;
 
-	@Column(columnDefinition = "TEXT")
-	private String url;
-
 	private Long size;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/dife/api/model/dto/FileDto.java
+++ b/src/main/java/com/dife/api/model/dto/FileDto.java
@@ -22,8 +22,6 @@ public class FileDto {
 
 	private String size;
 
-	private String url;
-
 	@Enumerated(EnumType.STRING)
 	private Format format;
 

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -247,8 +247,8 @@ public class ChatService {
 
 				MultipartFile multipartFile = new Base64MultipartFile(imageBytes, fileName, contentType);
 				FileDto fileDto = fileService.upload(multipartFile);
-				awsS3ImageUrls.add(fileDto.getUrl());
 
+				awsS3ImageUrls.add(fileService.getPresignUrl(fileDto.getId()));
 			} catch (IOException ex) {
 				log.error("IOException Error Message : {}", ex.getMessage());
 				ex.printStackTrace();

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -595,12 +595,8 @@ public class MemberService {
 									memberModelMapper.map(member, MemberResponseDto.class);
 							responseDto.setIsLiked(likeService.isLikeListMember(currentMember, member));
 							if (responseDto.getProfileImg() != null) {
-								try {
-									responseDto.setProfilePresignUrl(
-											fileService.getPresignUrl(member.getProfileImg().getOriginalName()));
-								} catch (IOException e) {
-									throw new RuntimeException(e);
-								}
+								responseDto.setProfilePresignUrl(
+										fileService.getPresignUrl(member.getProfileImg().getOriginalName()));
 							}
 							return responseDto;
 						})

--- a/src/main/java/com/dife/api/service/PostService.java
+++ b/src/main/java/com/dife/api/service/PostService.java
@@ -9,7 +9,6 @@ import com.dife.api.exception.PostNotFoundException;
 import com.dife.api.model.*;
 import com.dife.api.model.dto.*;
 import com.dife.api.repository.*;
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -63,11 +62,7 @@ public class PostService {
 							.map(
 									file -> {
 										FileDto fileDto = null;
-										try {
-											fileDto = fileService.upload(file);
-										} catch (IOException e) {
-											throw new RuntimeException(e);
-										}
+										fileDto = fileService.upload(file);
 										File mappedFile = modelMapper.map(fileDto, File.class);
 										mappedFile.setPost(post);
 										return mappedFile;
@@ -153,11 +148,7 @@ public class PostService {
 							.map(
 									file -> {
 										FileDto fileDto = null;
-										try {
-											fileDto = fileService.upload(file);
-										} catch (IOException e) {
-											throw new RuntimeException(e);
-										}
+										fileDto = fileService.upload(file);
 										File mappedFile = modelMapper.map(fileDto, File.class);
 										mappedFile.setPost(post);
 										return mappedFile;

--- a/src/main/resources/db/changelog/v1.0/v1.0.0.xml
+++ b/src/main/resources/db/changelog/v1.0/v1.0.0.xml
@@ -564,4 +564,8 @@
             <column name="type" type="varchar(50)"/>
         </addColumn>
     </changeSet>
+
+    <changeSet id="remove-url-column-from-file-20240824-2307" author="seungho">
+        <dropColumn tableName="file" columnName="url"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### 개요 및 수정 사항

- 현재 DB에 pre-signed url을 저장하고 있는데, pre-signed url은
일시적으로만 사용하는 것이므로 DB에 저장을 하지않도록 한다.
  - 프론트엔드 코드에서는 다행히 File 모델의 url 값을 필요로 하는 부분은 없어서
리팩토링 진행 (presignedImgProfile로 이미지 렌더링을 하더라구요)
- 반복되는 코드 genereatePresignedUrl 함수로 리팩토링
- exception의 경우에 global exception handler가 있으므로, try catch 걸지
않아도, 괜찮아서 삭제
