### PR TITLE
refactor/swagger-add-1: 배제해두었던 ChatroomSwagger 되살리기 & 모든 Controller 스…

### DIFF
--- a/src/main/java/com/dife/api/controller/ChatroomController.java
+++ b/src/main/java/com/dife/api/controller/ChatroomController.java
@@ -23,7 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @RequestMapping("/api/chatrooms")
 @Slf4j
-public class ChatroomController {
+public class ChatroomController implements SwaggerChatroomController {
 
 	private final ChatroomService chatroomService;
 
@@ -137,7 +137,7 @@ public class ChatroomController {
 	}
 
 	@GetMapping("/search")
-	public ResponseEntity<List<ChatroomResponseDto>> getFilterChatrooms(
+	public ResponseEntity<List<ChatroomResponseDto>> getSearchChatrooms(
 			@RequestParam(name = "keyword") String keyword, Authentication auth) {
 		List<ChatroomResponseDto> responseDto =
 				chatroomService.getSearchChatrooms(keyword, auth.getName());

--- a/src/main/java/com/dife/api/controller/FileController.java
+++ b/src/main/java/com/dife/api/controller/FileController.java
@@ -17,4 +17,9 @@ public class FileController implements SwaggerFileController {
 	public ResponseEntity<String> getFile(@PathVariable("id") Long id, Authentication auth) {
 		return ResponseEntity.ok(fileService.getPresignUrl(id, auth.getName()));
 	}
+
+	@GetMapping
+	public ResponseEntity<String> getFile(@RequestParam("name") String name) {
+		return ResponseEntity.ok(fileService.getPresignUrl(name));
+	}
 }

--- a/src/main/java/com/dife/api/controller/FileController.java
+++ b/src/main/java/com/dife/api/controller/FileController.java
@@ -1,9 +1,9 @@
 package com.dife.api.controller;
 
 import com.dife.api.service.FileService;
-import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -13,9 +13,8 @@ public class FileController implements SwaggerFileController {
 
 	private final FileService fileService;
 
-	@GetMapping
-	public ResponseEntity<String> getFile(@RequestParam(name = "fileName") String fileName)
-			throws IOException {
-		return ResponseEntity.ok(fileService.getPresignUrl(fileName));
+	@GetMapping("/{id}")
+	public ResponseEntity<String> getFile(@PathVariable("id") Long id, Authentication auth) {
+		return ResponseEntity.ok(fileService.getPresignUrl(id, auth.getName()));
 	}
 }

--- a/src/main/java/com/dife/api/controller/ReportController.java
+++ b/src/main/java/com/dife/api/controller/ReportController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/reports")
-public class ReportController {
+public class ReportController implements SwaggerReportController {
 
 	private final ReportService reportService;
 

--- a/src/main/java/com/dife/api/controller/SwaggerBookmarkController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerBookmarkController.java
@@ -26,7 +26,9 @@ public interface SwaggerBookmarkController {
 			})
 	ResponseEntity<List<BookmarkResponseDto>> getAllBookmarks(Authentication authentication);
 
-	@Operation(summary = "북마크 생성 API", description = "사용자가 DTO를 작성해 채팅/게시글 북마크를 생성하는 API입니다.")
+	@Operation(
+			summary = "북마크 생성 API",
+			description = "사용자가 DTO를 작성해 채팅/게시글 북마크를 생성하는 API입니다. 북마크 타입 : CHAT, POST, COMMENT")
 	@ApiResponse(
 			responseCode = "201",
 			description = "북마크 생성 성공 예시",

--- a/src/main/java/com/dife/api/controller/SwaggerChatroomController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerChatroomController.java
@@ -1,6 +1,7 @@
 package com.dife.api.controller;
 
 import com.dife.api.model.ChatroomType;
+import com.dife.api.model.GroupPurposeType;
 import com.dife.api.model.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -21,14 +22,14 @@ public interface SwaggerChatroomController {
 
 	@Operation(summary = "채팅방 중복 이름 확인 API", description = "사용자가 채팅방 이름을 검색해 중복성을 검사하는 API입니다.")
 	@ApiResponse(responseCode = "200")
-	ResponseEntity<Void> checkUsername(@RequestParam(name = "name") String name);
+	ResponseEntity<Void> checkChatroomName(@RequestParam(name = "name") String name);
 
 	@Operation(
-			summary = "채팅방 생성1 API",
+			summary = "채팅방 생성 API",
 			description = "사용자가 multipart/form-data 형태의 POST요청으로 그룹 채팅방을 생성하는 API입니다.")
 	@ApiResponse(
 			responseCode = "201",
-			description = "그룹 채팅방1 생성 성공 예시",
+			description = "그룹 채팅방 생성 성공 예시",
 			content = {
 				@Content(
 						mediaType = "application/json",
@@ -42,15 +43,17 @@ public interface SwaggerChatroomController {
 			@RequestParam(name = "toMemberId", required = false) Long toMemberId,
 			@RequestParam(name = "hobbies", required = false) Set<String> hobbies,
 			@RequestParam(name = "maxCount", required = false) Optional<Integer> maxCount,
-			@RequestParam(name = "purposes", required = false) Set<String> purposes,
+			@RequestParam(name = "purposes", required = false) Set<GroupPurposeType> purposes,
 			@RequestParam(name = "languages", required = false) Set<String> languages,
 			@RequestParam(name = "isPublic", required = false) Boolean isPublic,
 			@RequestParam(name = "password", required = false) String password,
-			Authentication authentication);
+			Authentication authentication)
+			throws IOException;
 
 	@Operation(
 			summary = "채팅방 세부사항 업데이트 API",
-			description = "사용자가 DTO를 작성해 PUT요청으로 그룹 채팅방 정보 업데이트를 진행하는 API입니다. 방장만이 접근할 수 있는 API입니다.")
+			description =
+					"사용자가 multipart/form-data 형태의 PUT요청으로 그룹 채팅방 정보 업데이트를 진행하는 API입니다. 방장만이 접근할 수 있는 API입니다.")
 	@ApiResponse(
 			responseCode = "200",
 			description = "그룹 채팅방 업데이트 성공 예시",
@@ -64,11 +67,12 @@ public interface SwaggerChatroomController {
 			@RequestParam(name = "profileImg", required = false) MultipartFile profileImg,
 			@RequestParam(name = "hobbies", required = false) Set<String> hobbies,
 			@RequestParam(name = "maxCount", required = false) Optional<Integer> maxCount,
-			@RequestParam(name = "purpose", required = false) Set<String> purposes,
+			@RequestParam(name = "purpose", required = false) Set<GroupPurposeType> purposes,
 			@RequestParam(name = "languages", required = false) Set<String> languages,
 			@RequestParam(name = "isPublic", required = false) Boolean isPublic,
 			@RequestParam(name = "password", required = false) String password,
-			Authentication auth);
+			Authentication auth)
+			throws IOException;
 
 	@Operation(summary = "채팅방 회원 강퇴 API", description = "채팅방 방장만이 회원 강퇴 권한을 갖는 API입니다.")
 	@ApiResponse(responseCode = "200", description = "그룹 채팅방 강퇴 성공 예시")
@@ -106,7 +110,7 @@ public interface SwaggerChatroomController {
 			@PathVariable(name = "id") Long id, Authentication auth) throws IOException;
 
 	@Operation(
-			summary = "그룹 채팅방 필터 검색 조회 API",
+			summary = "그룹 채팅방 필터 조회 API",
 			description =
 					"세부적인 그룹 채팅방 조회 필터링 선택지를 사용자에게 제시해 해당하는 그룹 채팅방을 조회할 수 있게 됩니다. 채팅방 목적, 취미, 언어의 복수 선택, 단일 종류 선택 가능한 name Set을 입력받게 됩니다.")
 	@ApiResponse(
@@ -120,12 +124,12 @@ public interface SwaggerChatroomController {
 	ResponseEntity<List<ChatroomResponseDto>> getFilterChatrooms(
 			@RequestParam(name = "hobbies", required = false) Set<String> hobbies,
 			@RequestParam(name = "languages", required = false) Set<String> languages,
-			@RequestParam(name = "purposes", required = false) Set<String> purposes,
+			@RequestParam(name = "purposes", required = false) Set<GroupPurposeType> purposes,
 			@RequestParam(name = "maxCount", required = false, defaultValue = "30") Integer maxCount,
 			Authentication auth);
 
 	@Operation(
-			summary = "채팅방 필터 검색 조회 API",
+			summary = "채팅방 검색 조회 API",
 			description = "채팅방 이름, 한줄 소개에 해당 검색어가 포함되는 채팅방들을 조회하는 API입니다.")
 	@ApiResponse(
 			responseCode = "200",
@@ -135,8 +139,8 @@ public interface SwaggerChatroomController {
 						mediaType = "application/json",
 						schema = @Schema(implementation = ChatroomResponseDto.class))
 			})
-	ResponseEntity<List<ChatroomResponseDto>> getFilterChatrooms(
-			@RequestParam(name = "keyword") String keyword);
+	ResponseEntity<List<ChatroomResponseDto>> getSearchChatrooms(
+			@RequestParam(name = "keyword") String keyword, Authentication auth);
 
 	@Operation(summary = "회원이 좋아요 누른 그룹 채팅방 목록 조회 API")
 	@ApiResponse(

--- a/src/main/java/com/dife/api/controller/SwaggerFileController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerFileController.java
@@ -3,9 +3,9 @@ package com.dife.api.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.IOException;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "File API", description = "파일 서비스 API")
 public interface SwaggerFileController {
@@ -13,8 +13,7 @@ public interface SwaggerFileController {
 	@Operation(
 			summary = "업로드된 이미지 파일 presignurl 조회 API",
 			description =
-					"조회하고자 하는 이미지 파일의 이름(OriginalName - ex. cookie.jpeg) 을 입력해 이미지 파일의 presignUrl을 확인할 수 있는 API입니다. 존재하지 않는 파일을 업로드 해도 presignUrl이 나오지만 No Such element라는 xml이 표시될 것입니다.")
+					"조회하고자 하는 이미지 파일의 고유 Id로 URL GET요청을 통해 이미지 파일의 presignUrl을 확인할 수 있는 API입니다. 존재하지 않는 파일을 업로드 해도 presignUrl이 나오지만 No Such element라는 xml이 표시될 것입니다.")
 	@ApiResponse(responseCode = "200")
-	ResponseEntity<String> getFile(@RequestParam(name = "fileName") String fileName)
-			throws IOException;
+	ResponseEntity<String> getFile(@PathVariable("id") Long id, Authentication auth);
 }

--- a/src/main/java/com/dife/api/controller/SwaggerLikeController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerLikeController.java
@@ -27,11 +27,16 @@ public interface SwaggerLikeController {
 			})
 	ResponseEntity<List<PostResponseDto>> getLikedPosts(Authentication auth);
 
-	@Operation(summary = "게시글/댓글 좋아요 생성 API", description = "사용자가 DTO를 작성해 게시글/댓글 좋아요를 생성하는 API입니다.")
+	@Operation(
+			summary = "좋아요 생성 API",
+			description =
+					"사용자가 DTO를 작성해 게시글/댓글/채팅방/회원 좋아요를 생성하는 API입니다. type은 POST/COMMENT/CHATROOM/MEMBER이 있습니다.")
 	@ApiResponse(responseCode = "201")
 	ResponseEntity<Void> createLike(LikeCreateRequestDto requestDto, Authentication auth);
 
-	@Operation(summary = "게시글/댓글 좋아요 취소 API", description = "사용자가 DTO를 작성해 게시글/댓글 좋아요를 취소하는 API입니다.")
+	@Operation(
+			summary = "좋아요 취소 API",
+			description = "사용자가 DTO를 작성해 좋아요를 취소하는 API입니다. 좋아요 생성과 같은 DTO를 사용합니다.")
 	@ApiResponse(responseCode = "200")
 	ResponseEntity<Void> deleteLikePost(LikeCreateRequestDto requestDto, Authentication auth);
 }

--- a/src/main/java/com/dife/api/controller/SwaggerNotificationController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerNotificationController.java
@@ -14,6 +14,17 @@ import org.springframework.web.bind.annotation.PathVariable;
 @Tag(name = "Notification API", description = "알림 서비스 API")
 public interface SwaggerNotificationController {
 
+	@Operation(summary = "알림 토큰 조회 API", description = "인가를 이용해 사용자의 모든 종류의 알림 토큰을 조회하는 API입니다.")
+	@ApiResponse(
+			responseCode = "200",
+			description = "단일 알림 토큰 조회 예시",
+			content = {
+				@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = NotificationTokenResponseDto.class))
+			})
+	ResponseEntity<List<NotificationTokenResponseDto>> getNotificationTokens(Authentication auth);
+
 	@Operation(summary = "알림 리스트 조회 API", description = "인가를 이용해 사용자의 알림을 조회하는 API입니다.")
 	@ApiResponse(
 			responseCode = "200",
@@ -37,4 +48,8 @@ public interface SwaggerNotificationController {
 			})
 	ResponseEntity<NotificationTokenResponseDto> createNotificationToken(
 			NotificationTokenRequestDto requestDto, Authentication auth);
+
+	@Operation(summary = "알림 삭제 API", description = "알림의 ID를 입력해 알림을 삭제할 수 있는 API입니다.")
+	@ApiResponse(responseCode = "200")
+	ResponseEntity<Void> deleteNotification(@PathVariable("id") Long id, Authentication auth);
 }

--- a/src/main/java/com/dife/api/controller/SwaggerReportController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerReportController.java
@@ -1,0 +1,19 @@
+package com.dife.api.controller;
+
+import com.dife.api.model.dto.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Report API", description = "신고 API")
+public interface SwaggerReportController {
+
+	@Operation(
+			summary = "신고 생성 API",
+			description =
+					"사용자가 신고 내용인(type)을 작성하고 신고하고자 하는 게시글/댓글/사용자 ID를 작성한 DTO를 생성해 신고 서비스를 진행하는 API입니다.")
+	ResponseEntity<ReportResponseDto> createDeclaration(
+			@RequestBody ReportRequestDto requestDto, Authentication auth);
+}

--- a/src/main/java/com/dife/api/model/ChatroomSetting.java
+++ b/src/main/java/com/dife/api/model/ChatroomSetting.java
@@ -36,7 +36,7 @@ public class ChatroomSetting extends BaseTimeEntity {
 	@OneToMany(mappedBy = "chatroomSetting", cascade = CascadeType.ALL)
 	private Set<Language> languages = new HashSet<>();
 
-	private Boolean isPublic;
+	private Boolean isPublic = true;
 
 	@Size(min = 5, max = 5, message = "비밀번호는 정확히 5자 이어야 합니다.")
 	@Pattern(regexp = "^[0-9]{5}$", message = "비밀번호는 숫자 5자로 구성되어야 합니다.")

--- a/src/main/java/com/dife/api/model/File.java
+++ b/src/main/java/com/dife/api/model/File.java
@@ -23,6 +23,8 @@ public class File extends BaseTimeEntity {
 
 	private String name;
 
+	private Boolean isSecret = false;
+
 	private Long size;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -248,7 +248,7 @@ public class ChatService {
 				MultipartFile multipartFile = new Base64MultipartFile(imageBytes, fileName, contentType);
 				FileDto fileDto = fileService.upload(multipartFile);
 
-				awsS3ImageUrls.add(fileService.getPresignUrl(fileDto.getId()));
+				awsS3ImageUrls.add(fileService.getPresignUrl(fileDto.getId(), member.getEmail()));
 			} catch (IOException ex) {
 				log.error("IOException Error Message : {}", ex.getMessage());
 				ex.printStackTrace();

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -130,6 +130,7 @@ public class ChatroomService {
 
 		setting.setCount(setting.getCount() + 1);
 		setting.setDescription(trimmedDescription);
+		setting.setIsPublic(isPublic);
 
 		chatroom.setChatroomSetting(setting);
 		chatroomRepository.save(chatroom);
@@ -230,17 +231,9 @@ public class ChatroomService {
 			givenSetting.setMaxCount(maxCountValue);
 		}
 
-		if (Boolean.FALSE.equals(isPublic)) {
-			givenSetting.setPassword(password);
-		}
-
-		if (givenSetting.getIsPublic() != null && isPublic == null)
-			givenSetting.setIsPublic(givenSetting.getIsPublic());
-		else if (isPublic == null) throw new ChatroomException("공개/비공개 여부는 필수입니다!");
-		else givenSetting.setIsPublic(isPublic);
-
-		if (Boolean.FALSE.equals(isPublic)) {
-			givenSetting.setPassword(password);
+		if (isPublic != null) {
+			givenSetting.setIsPublic(isPublic);
+			if (!isPublic) givenSetting.setPassword(password);
 		}
 
 		if (profileImg != null && !profileImg.isEmpty()) {
@@ -248,6 +241,9 @@ public class ChatroomService {
 			File file = modelMapper.map(profileImgPath, File.class);
 			givenSetting.setProfileImg(file);
 		}
+
+		givenChatroom.setChatroomSetting(givenSetting);
+		chatroomRepository.save(givenChatroom);
 
 		ChatroomResponseDto responseDto =
 				chatroomModelMapper.map(givenSetting, ChatroomResponseDto.class);

--- a/src/main/java/com/dife/api/service/FileService.java
+++ b/src/main/java/com/dife/api/service/FileService.java
@@ -87,9 +87,6 @@ public class FileService {
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 
 		File file = fileRepository.findById(fileId).orElseThrow(S3FileNotFoundException::new);
-		log.info(String.valueOf(file.getIsSecret()));
-		log.info(String.valueOf(member.getVerificationFile().getId()));
-		log.info(String.valueOf(fileId));
 		if (file.getIsSecret() && !fileId.equals(member.getVerificationFile().getId()))
 			throw new MemberException("회원만이 본인 인증 파일에 접근할 수 있습니다.");
 		return generatePresignedUrl(file.getName());

--- a/src/main/java/com/dife/api/service/FileService.java
+++ b/src/main/java/com/dife/api/service/FileService.java
@@ -1,14 +1,19 @@
 package com.dife.api.service;
 
+import com.dife.api.exception.MemberException;
+import com.dife.api.exception.MemberNotFoundException;
 import com.dife.api.exception.file.S3FileNameInvalidException;
 import com.dife.api.exception.file.S3FileNotFoundException;
 import com.dife.api.model.File;
 import com.dife.api.model.Format;
+import com.dife.api.model.Member;
 import com.dife.api.model.dto.FileDto;
 import com.dife.api.repository.FileRepository;
+import com.dife.api.repository.MemberRepository;
 import java.io.IOException;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -26,8 +31,10 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class FileService {
 	private final FileRepository fileRepository;
+	private final MemberRepository memberRepository;
 	private final S3Client s3Client;
 	private final S3Presigner presigner;
 	private final ModelMapper modelMapper;
@@ -74,8 +81,17 @@ public class FileService {
 		return generatePresignedUrl(fileName);
 	}
 
-	public String getPresignUrl(Long fileId) {
+	public String getPresignUrl(Long fileId, String memberEmail) {
+
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
+
 		File file = fileRepository.findById(fileId).orElseThrow(S3FileNotFoundException::new);
+		log.info(String.valueOf(file.getIsSecret()));
+		log.info(String.valueOf(member.getVerificationFile().getId()));
+		log.info(String.valueOf(fileId));
+		if (file.getIsSecret() && !fileId.equals(member.getVerificationFile().getId()))
+			throw new MemberException("회원만이 본인 인증 파일에 접근할 수 있습니다.");
 		return generatePresignedUrl(file.getName());
 	}
 

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -41,6 +41,7 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 	private final PostRepository postRepository;
+	private final FileRepository fileRepository;
 	private final BookmarkRepository bookmarkRepository;
 	private final LikePostRepository likePostRepository;
 	private final LikeCommentRepository likeCommentRepository;
@@ -110,16 +111,16 @@ public class MemberService {
 		Member member =
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 
-		if (!member.getIsVerified()) {
-			if ((verificationFile.isEmpty() || verificationFile == null)
-					&& (member.getUsername().equals(""))) {
-				throw new MemberNotAddVerificationException();
-			} else {
-				if (verificationFile != null && !verificationFile.isEmpty()) {
-					FileDto verificationImgPath = fileService.upload(verificationFile);
-					File file = modelMapper.map(verificationImgPath, File.class);
-					member.setVerificationFile(file);
-				}
+		if ((verificationFile == null || verificationFile.isEmpty())
+				&& member.getUsername().equals("")) {
+			throw new MemberNotAddVerificationException();
+		} else {
+			if (verificationFile != null && !verificationFile.isEmpty()) {
+				FileDto verificationImgPath = fileService.upload(verificationFile);
+				File file = modelMapper.map(verificationImgPath, File.class);
+				file.setIsSecret(true);
+				fileRepository.save(file);
+				member.setVerificationFile(file);
 			}
 		}
 

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -130,10 +130,10 @@ public class MemberService {
 			member.setProfileImg(file);
 		}
 
-		member.setUsername(username);
-		member.setCountry(country);
-		member.setBio(bio);
-		member.setMbti(mbti);
+		if (username != null) member.setUsername(username);
+		if (country != null) member.setCountry(country);
+		if (bio != null) member.setBio(bio);
+		if (mbti != null) member.setMbti(mbti);
 
 		if (hobbies != null) {
 			Set<String> safeHobbies = hobbies;

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -4,5 +4,5 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <includeAll path="db/changelog/v1.0"/>
+    <include file="db/changelog/v1.0/v1.0.1.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v1.0/v1.0.1.xml
+++ b/src/main/resources/db/changelog/v1.0/v1.0.1.xml
@@ -1,0 +1,577 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet id="1724477160246-1" author="suyeon">
+        <createTable tableName="bookmark">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_bookmark"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="message" type="varchar(300)"/>
+            <column name="member_id" type="bigint"/>
+            <column name="post_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-2" author="suyeon">
+        <createTable tableName="bookmark_translation">
+            <column name="bookmark_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="translation_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-3" author="suyeon">
+        <createTable tableName="chat">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_chat"/>
+            </column>
+            <column name="message" type="varchar(300)"/>
+            <column name="chatroom_id" type="bigint"/>
+            <column name="member_id" type="bigint"/>
+            <column name="created" type="datetime"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-4" author="suyeon">
+        <createTable tableName="chat_img_code">
+            <column name="chat_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="img_code" type="varchar(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-5" author="suyeon">
+        <createTable tableName="chatroom">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_chatroom"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="name" type="varchar(255)"/>
+            <column name="chatroom_type" type="varchar(20)"/>
+            <column name="chatroom_setting_id" type="bigint"/>
+            <column name="manager_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-6" author="suyeon">
+        <createTable tableName="chatroom_likes">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_chatroom_likes"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="chatroom_id" type="bigint"/>
+            <column name="member_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-7" author="suyeon">
+        <createTable tableName="chatroom_member">
+            <column name="chatroom_id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_chatroom_member"/>
+            </column>
+            <column name="member_id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_chatroom_member"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-8" author="suyeon">
+        <createTable tableName="chatroom_setting">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_chatroom_setting"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="description" type="varchar(60)"/>
+            <column name="profile_img_id" type="bigint"/>
+            <column name="count" type="INT"/>
+            <column name="max_count" type="INT"/>
+            <column name="is_public" type="boolean"/>
+            <column name="password" type="varchar(5)"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-9" author="suyeon">
+        <createTable tableName="comment">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_comment"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="content" type="varchar(255)"/>
+            <column name="is_public" type="boolean"/>
+            <column name="writer_id" type="bigint"/>
+            <column name="post_id" type="bigint"/>
+            <column name="parent_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-10" author="suyeon">
+        <createTable tableName="comment_likes">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_comment_likes"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="comment_id" type="bigint"/>
+            <column name="member_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-11" author="suyeon">
+        <createTable tableName="connect">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_connect"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="from_member_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="to_member_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-12" author="suyeon">
+        <createTable tableName="file">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_file"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="original_name" type="varchar(255)"/>
+            <column name="name" type="varchar(255)"/>
+            <column name="url" type="text"/>
+            <column name="size" type="bigint"/>
+            <column name="format" type="varchar(10)"/>
+            <column name="post_id" type="bigint"/>
+            <column name="chat_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-13" author="suyeon">
+        <createTable tableName="group_purpose">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_group_purpose"/>
+            </column>
+            <column name="name" type="varchar(50)"/>
+            <column name="chatroom_setting_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-14" author="suyeon">
+        <createTable tableName="hobby">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_hobby"/>
+            </column>
+            <column name="name" type="varchar(50)"/>
+            <column name="member_id" type="bigint"/>
+            <column name="chatroom_setting_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-15" author="suyeon">
+        <createTable tableName="language">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_language"/>
+            </column>
+            <column name="name" type="varchar(50)"/>
+            <column name="member_id" type="bigint"/>
+            <column name="chatroom_setting_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-16" author="suyeon">
+        <createTable tableName="member">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_member"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="email" type="varchar(100)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="password" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="username" type="varchar(30)"/>
+            <column name="name" type="varchar(50)"/>
+            <column name="student_id" type="varchar(30)"/>
+            <column name="major" type="varchar(50)"/>
+            <column name="role" type="varchar(50)"/>
+            <column name="verification_file_id" type="bigint"/>
+            <column name="country" type="varchar(50)"/>
+            <column name="is_public" type="boolean"/>
+            <column name="mbti" type="char(4)"/>
+            <column name="profile_img_id" type="bigint"/>
+            <column name="bio" type="varchar(255)"/>
+            <column name="is_verified" type="boolean"/>
+            <column name="is_deleted" type="boolean"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-17" author="suyeon">
+        <createTable tableName="member_blocks">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_member_blocks"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="member_id" type="bigint"/>
+            <column name="blacklisted_member_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-18" author="suyeon">
+        <createTable tableName="member_likelist">
+            <column name="likelisted_member_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="member_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-19" author="suyeon">
+        <createTable tableName="notification">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_notification"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="type" type="varchar(30)"/>
+            <column name="type_id" type="bigint"/>
+            <column name="chat_member_email" type="varchar(100)"/>
+            <column name="message" type="varchar(255)"/>
+            <column name="notification_token_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-20" author="suyeon">
+        <createTable tableName="notification_token">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_notification_token"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="push_token" type="varchar(255)"/>
+            <column name="device_id" type="varchar(255)"/>
+            <column name="member_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-21" author="suyeon">
+        <createTable tableName="post">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_post"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="title" type="varchar(100)"/>
+            <column name="content" type="varchar(255)"/>
+            <column name="is_public" type="boolean"/>
+            <column name="board_type" type="varchar(20)"/>
+            <column name="member_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-22" author="suyeon">
+        <createTable tableName="post_blocks">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_post_blocks"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="post_id" type="bigint"/>
+            <column name="member_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-23" author="suyeon">
+        <createTable tableName="post_likes">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_post_likes"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="post_id" type="bigint"/>
+            <column name="member_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-24" author="suyeon">
+        <createTable tableName="report">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_report"/>
+            </column>
+            <column name="created" type="datetime"/>
+            <column name="modified" type="datetime"/>
+            <column name="type" type="varchar(20)"/>
+            <column name="description" type="varchar(255)"/>
+            <column name="member_id" type="bigint"/>
+            <column name="post_id" type="bigint"/>
+            <column name="comment_id" type="bigint"/>
+            <column name="receiver_id" type="bigint"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-25" author="suyeon">
+        <createTable tableName="translation">
+            <column autoIncrement="true" name="id" type="bigint">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="pk_translation"/>
+            </column>
+            <column name="detected_source_language" type="varchar(255)"/>
+            <column name="text" type="varchar(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-26" author="suyeon">
+        <createTable tableName="translation_bookmarks">
+            <column name="translation_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="bookmarks_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="1724477160246-27" author="suyeon">
+        <addUniqueConstraint columnNames="from_member_id, to_member_id" constraintName="uc_8696a20e4c4fbce8beb84daf4"
+                             tableName="connect"/>
+    </changeSet>
+    <changeSet id="1724477160246-28" author="suyeon">
+        <addUniqueConstraint columnNames="chatroom_setting_id" constraintName="uc_chatroom_chatroom_setting"
+                             tableName="chatroom"/>
+    </changeSet>
+    <changeSet id="1724477160246-29" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="bookmark"
+                                 constraintName="FK_BOOKMARK_ON_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-30" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="post_id" baseTableName="bookmark" constraintName="FK_BOOKMARK_ON_POST"
+                                 referencedColumnNames="id" referencedTableName="post"/>
+    </changeSet>
+    <changeSet id="1724477160246-31" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="chatroom_id" baseTableName="chatroom_likes"
+                                 constraintName="FK_CHATROOM_LIKES_ON_CHATROOM" referencedColumnNames="id"
+                                 referencedTableName="chatroom"/>
+    </changeSet>
+    <changeSet id="1724477160246-32" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="chatroom_likes"
+                                 constraintName="FK_CHATROOM_LIKES_ON_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-33" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="chatroom_setting_id" baseTableName="chatroom"
+                                 constraintName="FK_CHATROOM_ON_CHATROOM_SETTING" referencedColumnNames="id"
+                                 referencedTableName="chatroom_setting"/>
+    </changeSet>
+    <changeSet id="1724477160246-34" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="manager_id" baseTableName="chatroom"
+                                 constraintName="FK_CHATROOM_ON_MANAGER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-35" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="profile_img_id" baseTableName="chatroom_setting"
+                                 constraintName="FK_CHATROOM_SETTING_ON_PROFILEIMG" referencedColumnNames="id"
+                                 referencedTableName="file"/>
+    </changeSet>
+    <changeSet id="1724477160246-36" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="chatroom_id" baseTableName="chat" constraintName="FK_CHAT_ON_CHATROOM"
+                                 referencedColumnNames="id" referencedTableName="chatroom"/>
+    </changeSet>
+    <changeSet id="1724477160246-37" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="chat" constraintName="FK_CHAT_ON_MEMBER"
+                                 referencedColumnNames="id" referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-38" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="comment_id" baseTableName="comment_likes"
+                                 constraintName="FK_COMMENT_LIKES_ON_COMMENT" referencedColumnNames="id"
+                                 referencedTableName="comment"/>
+    </changeSet>
+    <changeSet id="1724477160246-39" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="comment_likes"
+                                 constraintName="FK_COMMENT_LIKES_ON_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-40" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="parent_id" baseTableName="comment"
+                                 constraintName="FK_COMMENT_ON_PARENT" referencedColumnNames="id"
+                                 referencedTableName="comment"/>
+    </changeSet>
+    <changeSet id="1724477160246-41" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="post_id" baseTableName="comment" constraintName="FK_COMMENT_ON_POST"
+                                 referencedColumnNames="id" referencedTableName="post"/>
+    </changeSet>
+    <changeSet id="1724477160246-42" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="writer_id" baseTableName="comment"
+                                 constraintName="FK_COMMENT_ON_WRITER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-43" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="from_member_id" baseTableName="connect"
+                                 constraintName="FK_CONNECT_ON_FROM_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-44" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="to_member_id" baseTableName="connect"
+                                 constraintName="FK_CONNECT_ON_TO_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-45" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="chat_id" baseTableName="file" constraintName="FK_FILE_ON_CHAT"
+                                 referencedColumnNames="id" referencedTableName="chat"/>
+    </changeSet>
+    <changeSet id="1724477160246-46" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="post_id" baseTableName="file" constraintName="FK_FILE_ON_POST"
+                                 referencedColumnNames="id" referencedTableName="post"/>
+    </changeSet>
+    <changeSet id="1724477160246-47" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="chatroom_setting_id" baseTableName="group_purpose"
+                                 constraintName="FK_GROUP_PURPOSE_ON_CHATROOM_SETTING" referencedColumnNames="id"
+                                 referencedTableName="chatroom_setting"/>
+    </changeSet>
+    <changeSet id="1724477160246-48" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="chatroom_setting_id" baseTableName="hobby"
+                                 constraintName="FK_HOBBY_ON_CHATROOM_SETTING" referencedColumnNames="id"
+                                 referencedTableName="chatroom_setting"/>
+    </changeSet>
+    <changeSet id="1724477160246-49" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="hobby" constraintName="FK_HOBBY_ON_MEMBER"
+                                 referencedColumnNames="id" referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-50" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="chatroom_setting_id" baseTableName="language"
+                                 constraintName="FK_LANGUAGE_ON_CHATROOM_SETTING" referencedColumnNames="id"
+                                 referencedTableName="chatroom_setting"/>
+    </changeSet>
+    <changeSet id="1724477160246-51" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="language"
+                                 constraintName="FK_LANGUAGE_ON_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-52" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="blacklisted_member_id" baseTableName="member_blocks"
+                                 constraintName="FK_MEMBER_BLOCKS_ON_BLACKLISTED_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-53" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="member_blocks"
+                                 constraintName="FK_MEMBER_BLOCKS_ON_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-54" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="profile_img_id" baseTableName="member"
+                                 constraintName="FK_MEMBER_ON_PROFILEIMG" referencedColumnNames="id"
+                                 referencedTableName="file"/>
+    </changeSet>
+    <changeSet id="1724477160246-55" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="verification_file_id" baseTableName="member"
+                                 constraintName="FK_MEMBER_ON_VERIFICATIONFILE" referencedColumnNames="id"
+                                 referencedTableName="file"/>
+    </changeSet>
+    <changeSet id="1724477160246-56" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="notification_token_id" baseTableName="notification"
+                                 constraintName="FK_NOTIFICATION_ON_NOTIFICATION_TOKEN" referencedColumnNames="id"
+                                 referencedTableName="notification_token"/>
+    </changeSet>
+    <changeSet id="1724477160246-57" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="notification_token"
+                                 constraintName="FK_NOTIFICATION_TOKEN_ON_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-58" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="post_blocks"
+                                 constraintName="FK_POST_BLOCKS_ON_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-59" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="post_id" baseTableName="post_blocks"
+                                 constraintName="FK_POST_BLOCKS_ON_POST" referencedColumnNames="id"
+                                 referencedTableName="post"/>
+    </changeSet>
+    <changeSet id="1724477160246-60" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="post_likes"
+                                 constraintName="FK_POST_LIKES_ON_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-61" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="post_id" baseTableName="post_likes"
+                                 constraintName="FK_POST_LIKES_ON_POST" referencedColumnNames="id"
+                                 referencedTableName="post"/>
+    </changeSet>
+    <changeSet id="1724477160246-62" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="post" constraintName="FK_POST_ON_MEMBER"
+                                 referencedColumnNames="id" referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-63" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="comment_id" baseTableName="report"
+                                 constraintName="FK_REPORT_ON_COMMENT" referencedColumnNames="id"
+                                 referencedTableName="comment"/>
+    </changeSet>
+    <changeSet id="1724477160246-64" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="report" constraintName="FK_REPORT_ON_MEMBER"
+                                 referencedColumnNames="id" referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-65" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="post_id" baseTableName="report" constraintName="FK_REPORT_ON_POST"
+                                 referencedColumnNames="id" referencedTableName="post"/>
+    </changeSet>
+    <changeSet id="1724477160246-66" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="receiver_id" baseTableName="report"
+                                 constraintName="FK_REPORT_ON_RECEIVER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-67" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="bookmark_id" baseTableName="bookmark_translation"
+                                 constraintName="FK_BOOKMARK_TRANSLATION_ON_BOOKMARK" referencedColumnNames="id"
+                                 referencedTableName="bookmark"/>
+    </changeSet>
+    <changeSet id="1724477160246-68" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="translation_id" baseTableName="bookmark_translation"
+                                 constraintName="FK_BOOKMARK_TRANSLATION_ON_TRANSLATION" referencedColumnNames="id"
+                                 referencedTableName="translation"/>
+    </changeSet>
+    <changeSet id="1724477160246-69" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="chatroom_id" baseTableName="chatroom_member"
+                                 constraintName="FK_CHATROOM_MEMBER_ON_CHATROOM" referencedColumnNames="id"
+                                 referencedTableName="chatroom"/>
+    </changeSet>
+    <changeSet id="1724477160246-70" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="chatroom_member"
+                                 constraintName="FK_CHATROOM_MEMBER_ON_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-71" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="chat_id" baseTableName="chat_img_code"
+                                 constraintName="FK_CHAT_IMG_CODE_ON_CHAT" referencedColumnNames="id"
+                                 referencedTableName="chat"/>
+    </changeSet>
+    <changeSet id="1724477160246-72" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="likelisted_member_id" baseTableName="member_likelist"
+                                 constraintName="FK_MEMBER_LIKELIST_LIKELISTED_MEMBER_ID_ON_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-73" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="member_id" baseTableName="member_likelist"
+                                 constraintName="FK_MEMBER_LIKELIST_MEMBER_ID_ON_MEMBER" referencedColumnNames="id"
+                                 referencedTableName="member"/>
+    </changeSet>
+    <changeSet id="1724477160246-74" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="bookmarks_id" baseTableName="translation_bookmarks"
+                                 constraintName="FK_TRANSLATION_BOOKMARKS_ON_BOOKMARK" referencedColumnNames="id"
+                                 referencedTableName="bookmark"/>
+    </changeSet>
+    <changeSet id="1724477160246-75" author="suyeon">
+        <addForeignKeyConstraint baseColumnNames="translation_id" baseTableName="translation_bookmarks"
+                                 constraintName="FK_TRANSLATION_BOOKMARKS_ON_TRANSLATION" referencedColumnNames="id"
+                                 referencedTableName="translation"/>
+    </changeSet>
+    <changeSet id="add-type-column-to-group_purpose-20240824-1815" author="seungho">
+        <addColumn tableName="group_purpose">
+            <column name="type" type="varchar(50)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="remove-url-column-from-file-20240824-2307" author="seungho">
+        <dropColumn tableName="file" columnName="url"/>
+    </changeSet>
+
+    <changeSet id="add-type-column-from-file-20240826-0125" author="suyeon">
+        <addColumn tableName="file">
+            <column name="is_secret" type="boolean"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
…웨거 작성완료

#### 개요
- 모든 Controller Swagger 작성완료
- file id로 presignUrl 가져올 수 있도록 추가 (인가 삽입)
-> 이때 학생증 인증 파일이면 본인만 접근할 수 있게 조절 (커밋2 참고)
-> 기존의 file name으로 가져오는 코드 남겨둠
- 누락되었던 update null 방지 코드 mulipart/form-data 생성 형태인 회원/채팅방에 적용