### PR TITLE
feat/chat-jwt-implementation-1: JWT 도입

### DIFF
--- a/src/main/java/com/dife/api/controller/SocketController.java
+++ b/src/main/java/com/dife/api/controller/SocketController.java
@@ -2,7 +2,7 @@ package com.dife.api.controller;
 
 import com.dife.api.model.dto.ChatRequestDto;
 import com.dife.api.service.ChatService;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.*;
@@ -18,7 +18,7 @@ public class SocketController {
 
 	@MessageMapping("/chatroom/chat")
 	public void sendMessage(ChatRequestDto dto, SimpMessageHeaderAccessor headerAccessor)
-			throws JsonProcessingException {
+			throws IOException {
 		chatService.sendMessage(dto, headerAccessor);
 	}
 }

--- a/src/main/java/com/dife/api/handler/DisconnectHandler.java
+++ b/src/main/java/com/dife/api/handler/DisconnectHandler.java
@@ -4,6 +4,7 @@ import com.dife.api.model.Chatroom;
 import com.dife.api.model.ChatroomSetting;
 import com.dife.api.model.ChatroomType;
 import com.dife.api.model.Member;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
@@ -67,6 +68,11 @@ public class DisconnectHandler {
 	public boolean isEmpty(Chatroom chatroom) {
 		ChatroomSetting setting = chatroom.getChatroomSetting();
 		return setting.getCount() < 1;
+	}
+
+	public boolean isChatroomMember(Chatroom chatroom, Member member) {
+		Set<Member> chatroomMembers = chatroom.getMembers();
+		return chatroomMembers.contains(member);
 	}
 
 	public void disconnect(Long chatroomId, String sessionId) {

--- a/src/main/java/com/dife/api/model/dto/ChatRedisDto.java
+++ b/src/main/java/com/dife/api/model/dto/ChatRedisDto.java
@@ -20,6 +20,8 @@ public class ChatRedisDto {
 	@Size(max = 300)
 	private String message;
 
+	private String authorization;
+
 	private List<String> imgCode;
 
 	private MemberResponseDto member;

--- a/src/main/java/com/dife/api/model/dto/ChatRequestDto.java
+++ b/src/main/java/com/dife/api/model/dto/ChatRequestDto.java
@@ -23,7 +23,7 @@ public class ChatRequestDto {
 	private String password;
 	private String message;
 	private Long chatroomId;
-	private Long memberId;
+	private String authorization;
 	private String username;
 	private LocalDateTime created;
 	private List<String> imgCode;


### PR DESCRIPTION
#### 개요
- 기존 STOMP 기반 채팅 서비스에 JWT 토큰 검증을 도입한 PR입니다.
- 서로 다른 서버에서 채팅 검증을 테스트해보았습니다.

---


### 1. JWT 토큰 검증 

- header에 넣어 검증하려 했으나 StompHeaderAccessor로 getHeader/Decode해왔을 때 모두 null로 가져와져서 임시로 body로 가져왔습니다ㅠ!
```
{
    "authorization": "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MywidHlwZSI6ImFjY2Vzc1Rva2VuIiwiaXNzIjoiZGlmZSIsImlhdCI6MTcyNDg1NDQwNCwiZXhwIjoxNzI0ODU4MDA0fQ.Q7lfE_LfnKLRqvT3oV-qu3yBYuMzJI2lpkdt-Un-lTQ",
    "chatroomType" : "GROUP",
    "chatType" : "ENTER",
    "chatroomId": 2,
    "password" : "22222"
}
```

---

### 2. 서로 다른 서버에서 채팅 검증 확인사항

준비
- Application 에 가상 서버 준비 `-Dserver.port=8081`
<img width="1041" alt="스크린샷 2024-08-29 오전 12 39 15" src="https://github.com/user-attachments/assets/75a0b901-4b1e-4f38-bd69-7dc7ef4cc134">

확인사항
```
- 서로 다른 서버에서 채팅 보냈을 시에 같은 채팅방에 속해있는 회원들의 session으로 채팅오는지 확인 완료
- 같은 서버에서 다른 채팅방으로 메시지 보냈을 때 각기 채팅방으로 채팅오는지 확인 완료
```



