### PR TITLE
hotfix(translate): production에서 부재한 deepl key 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,16 @@ spring:
         redis:
             host: ${REDIS_HOST}
             port: ${REDIS_PORT}
+translation:
+    api-key: ${DEEPL_TRANSLATE_API_KEY}
+
+logging:
+    level:
+        org:
+            springframework:
+                messaging: trace
+                web:
+                    socket: trace
 
 jwt:
     secret: ${JWT_SECRET}


### PR DESCRIPTION
### 개요

- production에서 에러가 나서 확인해보니, production에서 deepL key가 부재한다. 따라서, 이를 추가해준다.

### 수정 사항

- 추가로, 한시적으로 웹소켓 디버깅을하기 위해, logging을 활성화한다.