### PR TITLE
Perf/member module : MemberService 모듈화 및 비밀번호 변경 후 로직 추가

### DIFF
--- a/src/main/java/com/dife/api/controller/MemberController.java
+++ b/src/main/java/com/dife/api/controller/MemberController.java
@@ -51,6 +51,7 @@ public class MemberController implements SwaggerMemberController {
 
 	@PutMapping(consumes = "multipart/form-data")
 	public ResponseEntity<MemberResponseDto> update(
+			@RequestParam(name = "password", required = false) String password,
 			@RequestParam(name = "username", required = false) String username,
 			@RequestParam(name = "country", required = false) String country,
 			@RequestParam(name = "settingLanguage", required = false) String settingLanguage,
@@ -61,11 +62,11 @@ public class MemberController implements SwaggerMemberController {
 			@RequestParam(name = "profileImg", required = false) MultipartFile profileImg,
 			@RequestParam(name = "verificationFile", required = false) MultipartFile verificationFile,
 			@RequestParam(name = "isPublic", required = false) Boolean isPublic,
-			Authentication auth)
-			throws IOException {
+			Authentication auth) {
 
 		MemberResponseDto responseDto =
 				memberService.update(
+						password,
 						username,
 						country,
 						settingLanguage,
@@ -82,13 +83,13 @@ public class MemberController implements SwaggerMemberController {
 
 	@GetMapping("/{id}")
 	public ResponseEntity<MemberResponseDto> getById(
-			@PathVariable(name = "id") Long id, Authentication auth) throws IOException {
+			@PathVariable(name = "id") Long id, Authentication auth) {
 		MemberResponseDto responseDto = memberService.getMemberById(id, auth.getName());
 		return ResponseEntity.ok(responseDto);
 	}
 
 	@GetMapping("/profile")
-	public ResponseEntity<MemberResponseDto> profile(Authentication auth) throws IOException {
+	public ResponseEntity<MemberResponseDto> profile(Authentication auth) {
 		MemberResponseDto responseDto = memberService.getMember(auth.getName());
 		return ResponseEntity.ok(responseDto);
 	}
@@ -134,8 +135,7 @@ public class MemberController implements SwaggerMemberController {
 			@RequestParam(name = "mbtis", required = false) Set<MbtiCategory> mbtiCategories,
 			@RequestParam(name = "hobbies", required = false) Set<String> hobbies,
 			@RequestParam(name = "languages", required = false) Set<String> languages,
-			Authentication auth)
-			throws IOException {
+			Authentication auth) {
 		List<MemberResponseDto> responseDto =
 				memberService.getFilterMembers(mbtiCategories, hobbies, languages, auth.getName());
 		return ResponseEntity.ok(responseDto);

--- a/src/main/java/com/dife/api/controller/MemberController.java
+++ b/src/main/java/com/dife/api/controller/MemberController.java
@@ -110,8 +110,18 @@ public class MemberController implements SwaggerMemberController {
 	}
 
 	@GetMapping("/change-password")
-	public ResponseEntity<Void> changePassword(@RequestParam(name = "email") String email) {
+	public ResponseEntity<Void> sendChangeVerify(@RequestParam(name = "email") String email) {
 		memberService.changePassword(email);
+
+		return new ResponseEntity<>(OK);
+	}
+
+	@PatchMapping("/change-password")
+	public ResponseEntity<Void> changePassword(
+			@RequestParam(name = "verifyCode", required = false) String verifyCode,
+			@RequestParam(name = "newPassword", required = false) String newPassword,
+			@RequestParam(name = "email", required = false) String email) {
+		memberService.verifyChangePasswordCode(verifyCode, newPassword, email);
 
 		return new ResponseEntity<>(OK);
 	}

--- a/src/main/java/com/dife/api/controller/SwaggerMemberController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerMemberController.java
@@ -49,6 +49,7 @@ public interface SwaggerMemberController {
 						schema = @Schema(implementation = MemberResponseDto.class))
 			})
 	public ResponseEntity<MemberResponseDto> update(
+			@RequestParam(name = "password", required = false) String password,
 			@RequestParam(name = "username", required = false) String username,
 			@RequestParam(name = "country", required = false) String country,
 			@RequestParam(name = "settingLanguage", required = false) String settingLanguage,
@@ -59,8 +60,7 @@ public interface SwaggerMemberController {
 			@RequestParam(name = "profileImg", required = false) MultipartFile profileImg,
 			@RequestParam(name = "verificationFile", required = false) MultipartFile verificationFile,
 			@RequestParam(name = "isPublic", required = false) Boolean isPublic,
-			Authentication auth)
-			throws IOException;
+			Authentication auth);
 
 	@Operation(
 			summary = "회원 ID별 조회 API",

--- a/src/main/java/com/dife/api/controller/SwaggerMemberController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerMemberController.java
@@ -109,10 +109,19 @@ public interface SwaggerMemberController {
 	ResponseEntity<Void> checkToken(@Valid @RequestBody RefreshTokenRequestDto requestDto);
 
 	@Operation(
-			summary = "비밀번호 변경 API",
-			description = "이메일을 발송해 유저는 변경된 비밀번호를 받아 유효한 로그인을 진행할 수 있게 됩니다.")
+			summary = "비밀번호 변경 인증번호 발송 API",
+			description = "이메일을 발송해 유저는 비밀번호 변경 인증번호를 받아 비밀번호 변경 권한을 갖게 됩니다.")
 	@ApiResponse(responseCode = "200", description = "비밀번호 변경 발송 예시")
-	ResponseEntity<Void> changePassword(@RequestParam(name = "email") String email);
+	public ResponseEntity<Void> sendChangeVerify(@RequestParam(name = "email") String email);
+
+	@Operation(
+			summary = "비밀번호 변경 API",
+			description = "이메일을 통해 인증번호를 받은 유저는 인증번호를 입력해 비밀번호를 입력해 비밀번호를 변경하게 됩니다.")
+	@ApiResponse(responseCode = "200", description = "비밀번호 변경 예시")
+	ResponseEntity<Void> changePassword(
+			@RequestParam(name = "verifyCode", required = false) String verifyCode,
+			@RequestParam(name = "newPassword", required = false) String newPassword,
+			@RequestParam(name = "email", required = false) String email);
 
 	@Operation(
 			summary = "홈화면 랜덤 10개 회원 조회 API",

--- a/src/main/java/com/dife/api/exception/VerifyCodeNotFoundException.java
+++ b/src/main/java/com/dife/api/exception/VerifyCodeNotFoundException.java
@@ -1,0 +1,7 @@
+package com.dife.api.exception;
+
+public class VerifyCodeNotFoundException extends IllegalStateException {
+	public VerifyCodeNotFoundException() {
+		super("비밀번호 변경 메일을 보낸 후에 접근해주세요!");
+	}
+}

--- a/src/main/java/com/dife/api/model/Member.java
+++ b/src/main/java/com/dife/api/model/Member.java
@@ -24,7 +24,7 @@ public class Member extends BaseTimeEntity {
 
 	@NotNull private String password = "";
 
-	private Boolean isPasswordChanged = false;
+	private String verifyCode = "";
 
 	private String username = "Diver";
 

--- a/src/main/java/com/dife/api/model/Member.java
+++ b/src/main/java/com/dife/api/model/Member.java
@@ -24,6 +24,8 @@ public class Member extends BaseTimeEntity {
 
 	@NotNull private String password = "";
 
+	private Boolean isPasswordChanged = false;
+
 	private String username = "Diver";
 
 	private String name = "";

--- a/src/main/java/com/dife/api/model/dto/MemberResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/MemberResponseDto.java
@@ -34,9 +34,6 @@ public class MemberResponseDto {
 	@Schema(description = "프로필 공개 여부", example = "true")
 	private Boolean isPublic;
 
-	@Schema(description = "탈퇴된 회원 여부", example = "true")
-	private Boolean isDeleted = false;
-
 	@Schema(description = "프로필 좋아요 여부", example = "true")
 	private Boolean isLiked = false;
 

--- a/src/main/java/com/dife/api/service/MemberService.java
+++ b/src/main/java/com/dife/api/service/MemberService.java
@@ -499,12 +499,13 @@ public class MemberService {
 
 		if (Objects.equals(member.getVerifyCode(), "")) throw new VerifyCodeNotFoundException();
 
-		if (Objects.equals(verifyCode, member.getVerifyCode())) {
+		if (Objects.equals(verifyCode, member.getVerifyCode()) && newPassword != null) {
 			String encodedPassword = passwordEncoder.encode(newPassword);
 			member.setPassword(encodedPassword);
 			memberRepository.save(member);
 
-		} else throw new MemberException("비밀번호 변경 코드가 일치하지 않습니다!");
+		} else if (!Objects.equals(verifyCode, member.getVerifyCode()))
+			throw new MemberException("비밀번호 변경 코드가 일치하지 않습니다!");
 	}
 
 	public List<MemberResponseDto> getRandomMembers(int count, String email) {

--- a/src/main/resources/db/changelog/v1.0/v1.0.4.xml
+++ b/src/main/resources/db/changelog/v1.0/v1.0.4.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="add-type-column-from-member-20240905-0000" author="suyeon">
+        <addColumn tableName="member">
+            <column name="is_password_changed" type="boolean"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/v1.0/v1.0.4.xml
+++ b/src/main/resources/db/changelog/v1.0/v1.0.4.xml
@@ -4,9 +4,9 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet id="add-type-column-from-member-20240905-0000" author="suyeon">
+    <changeSet id="add-type-column-from-member-20240905-1900" author="suyeon">
         <addColumn tableName="member">
-            <column name="is_password_changed" type="boolean"/>
+            <column name="verify_code" type="varchar(10)"/>
         </addColumn>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### 개요
- MemberService 메서드 분리 및 비밀번호 변경 후 비밀번호 재설정 가능하도록 로직 추가한 PR입니다!
- NO AUTH 상태에서, 비밀번호 인증번호를 이용한,  비밀번호 변경을 용도의 PATCH 엔드포인트를 추가해두었습니다!


---

(edited) 테스트 시나리오 
비밀번호 까먹었을 때에 재설정
```
- GET :/members/change-password로 변경 메일 발송 (인증번호 받기 용도)
- 인증번호를 받은 후에 사용자는 NO AUTH (로그인 불가 상태이므로) 상태로 비밀번호 변경 인증번호, 변경할 새 비밀번호, 계정 이메일을 입력해 비밀번호를 변경하게 됨
```

Auth 상태에서 비밀번호 재설정
`- 이미 인증받은 사용자이므로 update PUT 요청에서 변경 가능할 수 있게 열어둠`

인증번호 불일치시 403 익셉션