### PR TITLE
fix(chat): 그룹 채팅 전용 조회 API를 1:1 겸용으로 개조

### DIFF
--- a/src/main/java/com/dife/api/controller/ChatroomController.java
+++ b/src/main/java/com/dife/api/controller/ChatroomController.java
@@ -38,7 +38,7 @@ public class ChatroomController implements SwaggerChatroomController {
 	}
 
 	@GetMapping
-	public ResponseEntity<List<ChatroomResponseDto>> getGroupChatrooms(
+	public ResponseEntity<List<ChatroomResponseDto>> getChatrooms(
 			@RequestParam(name = "type", required = false) ChatroomType type,
 			Authentication authentication) {
 		List<ChatroomResponseDto> responseDto =
@@ -47,7 +47,7 @@ public class ChatroomController implements SwaggerChatroomController {
 	}
 
 	@GetMapping("/{id}")
-	public ResponseEntity<ChatroomResponseDto> getGroupChatroom(
+	public ResponseEntity<ChatroomResponseDto> getChatroom(
 			@PathVariable(name = "id") Long chatroomId, Authentication auth) throws IOException {
 		ChatroomResponseDto responseDto = chatroomService.getChatroom(chatroomId, auth.getName());
 		return ResponseEntity.status(OK).body(responseDto);

--- a/src/main/java/com/dife/api/controller/SwaggerChatroomController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerChatroomController.java
@@ -93,7 +93,7 @@ public interface SwaggerChatroomController {
 						mediaType = "application/json",
 						schema = @Schema(implementation = ChatroomResponseDto.class))
 			})
-	ResponseEntity<List<ChatroomResponseDto>> getGroupChatrooms(
+	ResponseEntity<List<ChatroomResponseDto>> getChatrooms(
 			@RequestParam(name = "type", required = false) ChatroomType type,
 			Authentication authentication);
 
@@ -106,7 +106,7 @@ public interface SwaggerChatroomController {
 						mediaType = "application/json",
 						schema = @Schema(implementation = ChatroomResponseDto.class))
 			})
-	ResponseEntity<ChatroomResponseDto> getGroupChatroom(
+	ResponseEntity<ChatroomResponseDto> getChatroom(
 			@PathVariable(name = "id") Long id, Authentication auth) throws IOException;
 
 	@Operation(

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -327,7 +327,9 @@ public class ChatroomService {
 
 		ChatroomSetting setting = chatroom.getChatroomSetting();
 		ChatroomResponseDto responseDto = chatroomModelMapper.map(setting, ChatroomResponseDto.class);
-		responseDto.setManager(memberModelMapper.map(chatroom.getManager(), MemberResponseDto.class));
+		if (chatroom.getChatroomType() == ChatroomType.GROUP) {
+			responseDto.setManager(memberModelMapper.map(chatroom.getManager(), MemberResponseDto.class));
+		}
 		responseDto.setName(chatroom.getName());
 		responseDto.setProfileImg(chatroom.getChatroomSetting().getProfileImg());
 		if (chatroom.getMembers().contains(member)) responseDto.setIsEntered(true);

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -333,7 +333,10 @@ public class ChatroomService {
 		responseDto.setName(chatroom.getName());
 		responseDto.setProfileImg(chatroom.getChatroomSetting().getProfileImg());
 		if (chatroom.getMembers().contains(member)) responseDto.setIsEntered(true);
-		responseDto.getMembers().add(memberModelMapper.map(member, MemberResponseDto.class));
+		responseDto.setMembers(
+				chatroom.getMembers().stream()
+						.map(m -> memberModelMapper.map(m, MemberResponseDto.class))
+						.collect(Collectors.toSet()));
 		responseDto.setCreated(setting.getCreated());
 		responseDto.setModified(setting.getModified());
 


### PR DESCRIPTION
### 개요

- 현재 그룹채팅 전용으로 사용 중인 /chatrooms/getGroupChatrooms와 /chatrooms/getGroupChatroom을 1:1도 사용할 수 있도록 겸용으로 바꾼다.

### 수정 사항

- 함수명 변경
- 1:1 채팅의 경우에는 방장이 없으므로, null 값이 들어가서 에러가 남. 따라서, GROUP이 있는 경우에만 값처리를 해주자