### PR TITLE
perf/exceptMemberDto-1: 수정 회원 응답 DTO 적용 (MemberService 제외)

### DIFF
--- a/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/CommentResponseDto.java
@@ -30,7 +30,7 @@ public class CommentResponseDto {
 
 	private Integer bookmarkCount;
 
-	private MemberResponseDto writer;
+	private MemberRestrictedResponseDto writer;
 
 	private LocalDateTime created;
 

--- a/src/main/java/com/dife/api/model/dto/ConnectResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/ConnectResponseDto.java
@@ -1,7 +1,6 @@
 package com.dife.api.model.dto;
 
 import com.dife.api.model.ConnectStatus;
-import com.dife.api.model.Member;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.EnumType;
@@ -21,12 +20,12 @@ public class ConnectResponseDto {
 	@NotNull
 	@JsonProperty("from_member")
 	@Schema(description = "커넥트 요청 받는 회원의 회원정보", example = "Member엔티티 참고")
-	private Member fromMember;
+	private MemberRestrictedResponseDto fromMember;
 
 	@NotNull
 	@JsonProperty("to_member")
 	@Schema(description = "커넥트 요청 보내는 회원의 회원정보", example = "Member엔티티 참고")
-	private Member toMember;
+	private MemberRestrictedResponseDto toMember;
 
 	@NotNull
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/dife/api/model/dto/MemberRestrictedResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/MemberRestrictedResponseDto.java
@@ -14,19 +14,8 @@ public class MemberRestrictedResponseDto {
 
 	private Long id;
 
-	@Schema(description = "이메일 주소", example = "gusuyeon@gmail.com")
-	private String email;
-
 	@Schema(description = "닉네임", example = "sooya")
 	private String username;
-
-	@Schema(description = "국가코드", example = "KO")
-	private String country;
-
-	@Schema(description = "프로필 공개 여부", example = "true")
-	private Boolean isPublic;
-
-	private String settingLanguage = "EN";
 
 	@Schema(description = "S3에 저장되는 프로필 이미지", example = "cookie.jpeg")
 	private File profileImg;

--- a/src/main/java/com/dife/api/model/dto/NotificationTokenResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/NotificationTokenResponseDto.java
@@ -1,6 +1,5 @@
 package com.dife.api.model.dto;
 
-import com.dife.api.model.Member;
 import com.dife.api.model.Notification;
 import java.util.List;
 import lombok.Getter;
@@ -16,7 +15,7 @@ public class NotificationTokenResponseDto {
 
 	private String deviceId;
 
-	private Member member;
+	private MemberRestrictedResponseDto member;
 
 	private List<Notification> notifications;
 }

--- a/src/main/java/com/dife/api/model/dto/PostResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/PostResponseDto.java
@@ -39,5 +39,5 @@ public class PostResponseDto {
 
 	private List<File> files;
 
-	private MemberResponseDto writer;
+	private MemberRestrictedResponseDto writer;
 }

--- a/src/main/java/com/dife/api/service/BlockService.java
+++ b/src/main/java/com/dife/api/service/BlockService.java
@@ -36,9 +36,7 @@ public class BlockService {
 						.findById(requestDto.getMemberId())
 						.orElseThrow(MemberNotFoundException::new);
 
-		if (member.getId().equals(requestDto.getMemberId())) {
-			throw new MemberSendingSelfException();
-		}
+		if (member.getId().equals(requestDto.getMemberId())) throw new MemberSendingSelfException();
 
 		boolean isAlreadyBlacklisted = false;
 
@@ -50,9 +48,7 @@ public class BlockService {
 							.anyMatch(bl -> bl.getBlacklistedMember().getId().equals(blackMember.getId()));
 		}
 
-		if (isAlreadyBlacklisted) {
-			throw new DuplicateMemberException("이미 블랙리스트에 존재하는 회원입니다!");
-		}
+		if (isAlreadyBlacklisted) throw new DuplicateMemberException("이미 블랙리스트에 존재하는 회원입니다!");
 
 		MemberBlock memberBlock = new MemberBlock();
 		memberBlock.setMember(member);

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -105,9 +105,8 @@ public class ChatService {
 		Set<Member> chatroomMembers = chatroom.getMembers();
 		chatroomMembers.add(member);
 
-		for (Member chatroomMember : chatroomMembers) {
+		for (Member chatroomMember : chatroomMembers)
 			translateChatroomEnter(chatroomMember.getSettingLanguage(), member, chatroom);
-		}
 
 		redisPublisher.publish(dealDto(chat, member, chatroom));
 		chatroomRepository.save(chatroom);
@@ -144,9 +143,7 @@ public class ChatService {
 			return;
 		}
 
-		if (dto.getMessage().length() >= 300) {
-			throw new ChatroomException("채팅 메시지는 300자 이하로 입력해주세요!");
-		}
+		if (dto.getMessage().length() >= 300) throw new ChatroomException("채팅 메시지는 300자 이하로 입력해주세요!");
 
 		Chat chat = saveChat(member, chatroom, dto.getMessage());
 		Set<Member> chatroomMembers = chatroom.getMembers();
@@ -166,9 +163,7 @@ public class ChatService {
 					notification.setCreated(LocalDateTime.now());
 
 					String message = chat.getMessage();
-					if (message.length() > 30) {
-						message = message.substring(0, 30) + "...";
-					}
+					if (message.length() > 30) message = message.substring(0, 30) + "...";
 					notification.setMessage(message);
 					notificationToken.getNotifications().add(notification);
 

--- a/src/main/java/com/dife/api/service/CommentService.java
+++ b/src/main/java/com/dife/api/service/CommentService.java
@@ -7,7 +7,7 @@ import com.dife.api.exception.PostNotFoundException;
 import com.dife.api.model.*;
 import com.dife.api.model.dto.CommentCreateRequestDto;
 import com.dife.api.model.dto.CommentResponseDto;
-import com.dife.api.model.dto.MemberResponseDto;
+import com.dife.api.model.dto.MemberRestrictedResponseDto;
 import com.dife.api.repository.*;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -77,7 +77,8 @@ public class CommentService {
 		commentRepository.save(comment);
 
 		CommentResponseDto responseDto = modelMapper.map(comment, CommentResponseDto.class);
-		MemberResponseDto memberDto = memberModelMapper.map(writer, MemberResponseDto.class);
+		MemberRestrictedResponseDto memberDto =
+				modelMapper.map(writer, MemberRestrictedResponseDto.class);
 		responseDto.setPost(postService.getPost(comment.getPost().getId(), memberEmail));
 		responseDto.setWriter(memberDto);
 
@@ -132,7 +133,7 @@ public class CommentService {
 	public CommentResponseDto getComment(Comment comment, Member member) {
 		CommentResponseDto dto = modelMapper.map(comment, CommentResponseDto.class);
 
-		dto.setWriter(memberModelMapper.map(comment.getWriter(), MemberResponseDto.class));
+		dto.setWriter(modelMapper.map(comment.getWriter(), MemberRestrictedResponseDto.class));
 		dto.setPost(postService.getPost(comment.getPost().getId(), member.getEmail()));
 		dto.setLikesCount(comment.getCommentLikes().size());
 

--- a/src/main/java/com/dife/api/service/CommentService.java
+++ b/src/main/java/com/dife/api/service/CommentService.java
@@ -17,8 +17,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,10 +32,6 @@ public class CommentService {
 	private final CommentRepository commentRepository;
 	private final LikeCommentRepository likeCommentRepository;
 	private final PostService postService;
-
-	@Autowired
-	@Qualifier("memberModelMapper")
-	private ModelMapper memberModelMapper;
 
 	private final NotificationService notificationService;
 
@@ -155,9 +149,7 @@ public class CommentService {
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 		Comment comment = commentRepository.findById(id).orElseThrow(CommentNotFoundException::new);
 
-		if (!comment.getWriter().equals(member)) {
-			throw new MemberException("작성자만이 삭제를 진행할 수 있습니다!");
-		}
+		if (!comment.getWriter().equals(member)) throw new MemberException("작성자만이 삭제를 진행할 수 있습니다!");
 
 		if (!comment.getChildrenComments().isEmpty()) {
 			for (Comment childComment : comment.getChildrenComments()) {

--- a/src/main/java/com/dife/api/service/ConnectService.java
+++ b/src/main/java/com/dife/api/service/ConnectService.java
@@ -7,6 +7,7 @@ import com.dife.api.model.*;
 import com.dife.api.model.dto.ConnectPatchRequestDto;
 import com.dife.api.model.dto.ConnectRequestDto;
 import com.dife.api.model.dto.ConnectResponseDto;
+import com.dife.api.model.dto.MemberRestrictedResponseDto;
 import com.dife.api.repository.ConnectRepository;
 import com.dife.api.repository.MemberRepository;
 import java.util.ArrayList;
@@ -69,7 +70,10 @@ public class ConnectService {
 
 		Connect connect = connections.stream().findFirst().orElseThrow(ConnectNotFoundException::new);
 
-		return modelMapper.map(connect, ConnectResponseDto.class);
+		ConnectResponseDto responseDto = modelMapper.map(connect, ConnectResponseDto.class);
+		responseDto.setToMember(modelMapper.map(otherMember, MemberRestrictedResponseDto.class));
+		responseDto.setFromMember(modelMapper.map(currentMember, MemberRestrictedResponseDto.class));
+		return responseDto;
 	}
 
 	public ConnectResponseDto saveConnect(ConnectRequestDto dto, String currentMemberEmail) {
@@ -95,7 +99,10 @@ public class ConnectService {
 
 		translateCreateConnect(toMember.getSettingLanguage(), currentMember, toMember, connect);
 
-		return modelMapper.map(connect, ConnectResponseDto.class);
+		ConnectResponseDto responseDto = modelMapper.map(connect, ConnectResponseDto.class);
+		responseDto.setToMember(modelMapper.map(toMember, MemberRestrictedResponseDto.class));
+		responseDto.setFromMember(modelMapper.map(currentMember, MemberRestrictedResponseDto.class));
+		return responseDto;
 	}
 
 	public void acceptConnect(ConnectPatchRequestDto requestDto, String currentMemberEmail) {

--- a/src/main/java/com/dife/api/service/LikeService.java
+++ b/src/main/java/com/dife/api/service/LikeService.java
@@ -4,7 +4,6 @@ import com.dife.api.exception.*;
 import com.dife.api.model.*;
 import com.dife.api.model.dto.LikeCreateRequestDto;
 import com.dife.api.model.dto.LikeResponseDto;
-import com.dife.api.model.dto.PostResponseDto;
 import com.dife.api.repository.*;
 import java.util.List;
 import java.util.Locale;
@@ -12,6 +11,7 @@ import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +32,8 @@ public class LikeService {
 	private final NotificationService notificationService;
 	private final PostService postService;
 
+	private final ModelMapper modelMapper;
+
 	public List<LikeResponseDto> getLikedPosts(String memberEmail) {
 		Member member =
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
@@ -42,10 +44,10 @@ public class LikeService {
 				postLikes.stream()
 						.map(
 								postLike -> {
+									LikeResponseDto responseDto = modelMapper.map(postLike, LikeResponseDto.class);
 									Post post = postLike.getPost();
-									PostResponseDto postResponseDto = postService.getPost(post.getId(), memberEmail);
-
-									return new LikeResponseDto(postLike.getId(), postResponseDto);
+									responseDto.setPost(postService.getPost(post.getId(), memberEmail));
+									return responseDto;
 								})
 						.collect(Collectors.toList());
 

--- a/src/main/java/com/dife/api/service/NotificationService.java
+++ b/src/main/java/com/dife/api/service/NotificationService.java
@@ -9,6 +9,7 @@ import com.dife.api.model.Member;
 import com.dife.api.model.Notification;
 import com.dife.api.model.NotificationToken;
 import com.dife.api.model.NotificationType;
+import com.dife.api.model.dto.MemberRestrictedResponseDto;
 import com.dife.api.model.dto.NotificationResponseDto;
 import com.dife.api.model.dto.NotificationTokenRequestDto;
 import com.dife.api.model.dto.NotificationTokenResponseDto;
@@ -55,7 +56,7 @@ public class NotificationService {
 			member.getNotificationTokens().add(notificationToken);
 
 			notificationTokenRepository.save(notificationToken);
-			return modelMapper.map(notificationToken, NotificationTokenResponseDto.class);
+			return getNotificationResponseDto(notificationToken, member);
 		}
 		return modelMapper.map(
 				notificationTokenRepository.findByDeviceId(requestDto.getDeviceId()),
@@ -67,9 +68,7 @@ public class NotificationService {
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 		List<NotificationToken> notifications = notificationTokenRepository.findAllByMember(member);
 
-		return notifications.stream()
-				.map(n -> modelMapper.map(n, NotificationTokenResponseDto.class))
-				.collect(toList());
+		return notifications.stream().map(n -> getNotificationResponseDto(n, member)).collect(toList());
 	}
 
 	public List<NotificationResponseDto> getNotifications(String deviceId, String memberEmail) {
@@ -84,6 +83,14 @@ public class NotificationService {
 		return notificationToken.getNotifications().stream()
 				.map(notification -> modelMapper.map(notification, NotificationResponseDto.class))
 				.collect(toList());
+	}
+
+	public NotificationTokenResponseDto getNotificationResponseDto(
+			NotificationToken notificationToken, Member member) {
+		NotificationTokenResponseDto responseDto =
+				modelMapper.map(notificationToken, NotificationTokenResponseDto.class);
+		responseDto.setMember(modelMapper.map(member, MemberRestrictedResponseDto.class));
+		return responseDto;
 	}
 
 	public void sendPushNotification(String expoToken, LocalDateTime created, String message) {

--- a/src/main/java/com/dife/api/service/PostService.java
+++ b/src/main/java/com/dife/api/service/PostService.java
@@ -84,7 +84,7 @@ public class PostService {
 		postRepository.save(post);
 
 		PostResponseDto responseDto = modelMapper.map(post, PostResponseDto.class);
-		responseDto.setWriter(memberModelMapper.map(post.getWriter(), MemberResponseDto.class));
+		responseDto.setWriter(modelMapper.map(post.getWriter(), MemberRestrictedResponseDto.class));
 		return responseDto;
 	}
 
@@ -118,7 +118,7 @@ public class PostService {
 				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 
 		PostResponseDto responseDto = modelMapper.map(post, PostResponseDto.class);
-		responseDto.setWriter(memberModelMapper.map(post.getWriter(), MemberResponseDto.class));
+		responseDto.setWriter(modelMapper.map(post.getWriter(), MemberRestrictedResponseDto.class));
 		responseDto.setCommentCount(post.getComments().size());
 		responseDto.setLikesCount(post.getPostLikes().size());
 		responseDto.setBookmarkCount(post.getBookmarks().size());
@@ -176,7 +176,7 @@ public class PostService {
 		postRepository.save(post);
 
 		PostResponseDto responseDto = modelMapper.map(post, PostResponseDto.class);
-		responseDto.setWriter(memberModelMapper.map(post.getWriter(), MemberResponseDto.class));
+		responseDto.setWriter(modelMapper.map(post.getWriter(), MemberRestrictedResponseDto.class));
 		return responseDto;
 	}
 
@@ -251,7 +251,7 @@ public class PostService {
 						post -> {
 							PostResponseDto responseDto = modelMapper.map(post, PostResponseDto.class);
 							responseDto.setWriter(
-									memberModelMapper.map(post.getWriter(), MemberResponseDto.class));
+									modelMapper.map(post.getWriter(), MemberRestrictedResponseDto.class));
 							responseDto.setCommentCount(post.getComments().size());
 							responseDto.setLikesCount(post.getPostLikes().size());
 							responseDto.setBookmarkCount(post.getBookmarks().size());


### PR DESCRIPTION
### 개요
- 불필요한 회원정보를 제외한 회원 응답 DTO 변경 사항입니다!
- MemberService에는 제외함


```
@Getter
@Setter
@ToString
@AllArgsConstructor
@NoArgsConstructor
@Schema(description = "표시용 회원정보 응답 데이터 전송 객체")
public class MemberRestrictedResponseDto {

    private Long id;

    @Schema(description = "닉네임", example = "sooya")
    private String username;

    @Schema(description = "S3에 저장되는 프로필 이미지", example = "cookie.jpeg")
    private File profileImg;
}
```