### PR TITLE
Feat/chat authorization : 일대일 채팅 JWT Authorization 넣기 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.security:spring-security-messaging'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/dife/api/config/SecurityWebSockConfig.java
+++ b/src/main/java/com/dife/api/config/SecurityWebSockConfig.java
@@ -1,0 +1,24 @@
+package com.dife.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+public class SecurityWebSockConfig {
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http.authorizeHttpRequests(
+				authorize ->
+						authorize
+								.requestMatchers("/pub/**")
+								.authenticated()
+								.requestMatchers("/sub/**")
+								.authenticated()
+								.anyRequest()
+								.permitAll());
+		return http.build();
+	}
+}

--- a/src/main/java/com/dife/api/config/WebSockConfig.java
+++ b/src/main/java/com/dife/api/config/WebSockConfig.java
@@ -2,6 +2,7 @@ package com.dife.api.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.*;
 
@@ -9,6 +10,8 @@ import org.springframework.web.socket.config.annotation.*;
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSockConfig implements WebSocketMessageBrokerConfigurer {
+
+	private final WebSocketInterceptor webSocketInterceptor;
 
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -19,5 +22,10 @@ public class WebSockConfig implements WebSocketMessageBrokerConfigurer {
 	public void configureMessageBroker(MessageBrokerRegistry config) {
 		config.enableSimpleBroker("/sub");
 		config.setApplicationDestinationPrefixes("/pub");
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(webSocketInterceptor);
 	}
 }

--- a/src/main/java/com/dife/api/config/WebSocketInterceptor.java
+++ b/src/main/java/com/dife/api/config/WebSocketInterceptor.java
@@ -1,0 +1,54 @@
+package com.dife.api.config;
+
+import com.dife.api.jwt.JWTUtil;
+import com.dife.api.model.Member;
+import com.dife.api.repository.MemberRepository;
+import jakarta.security.auth.message.AuthException;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class WebSocketInterceptor implements ChannelInterceptor {
+
+	private final JWTUtil jwtUtil;
+	private final MemberRepository memberRepository;
+
+	@SneakyThrows
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor =
+				MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+		if (StompCommand.CONNECT.equals(accessor.getCommand())
+				|| StompCommand.SEND.equals(accessor.getCommand())) {
+			String authToken = accessor.getFirstNativeHeader("authorization");
+			String jwtToken = authToken.split(" ")[1];
+
+			if (jwtToken == null || jwtUtil.isExpired(jwtToken)) {
+				throw new AuthException("손상된 토큰입니다! 다시 로그인 하세요!");
+			}
+
+			Long id = jwtUtil.getId(jwtToken);
+
+			Member member =
+					memberRepository.findById(id).orElseThrow(() -> new AuthException("회원을 찾을 수 없습니다!"));
+
+			if (member.getVerificationFile() != null && !member.getIsVerified())
+				throw new AuthException("인증이 필요한 회원입니다!");
+			accessor.addNativeHeader("memberEmail", member.getEmail());
+		}
+		return message;
+	}
+}

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -78,8 +78,10 @@ public class ChatService {
 						.orElseThrow(ChatroomNotFoundException::new);
 		Long chatroomId = chatroom.getId();
 		String sessionId = headerAccessor.getSessionId();
+		String memberEmail = headerAccessor.getFirstNativeHeader("memberEmail");
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 
-		Member member = memberService.getMemberEntityById(dto.getMemberId());
 		if (!disconnectHandler.canEnterChatroom(chatroom, member, sessionId, dto.getPassword())) {
 			disconnectHandler.disconnect(chatroom.getId(), sessionId);
 			return;
@@ -134,7 +136,9 @@ public class ChatService {
 						.orElseThrow(ChatroomNotFoundException::new);
 
 		String sessionId = headerAccessor.getSessionId();
-		Member member = memberService.getMemberEntityById(dto.getMemberId());
+		String memberEmail = headerAccessor.getFirstNativeHeader("memberEmail");
+		Member member =
+				memberRepository.findByEmail(memberEmail).orElseThrow(MemberNotFoundException::new);
 
 		Set<Member> blockedMembers = blockService.getBlackSet(member);
 


### PR DESCRIPTION
### 개요
채팅에 JWT 토큰을 넣어 Authorization을 주입한 PR입니다!

Interceptor을 이용해 Authorization에서 회원 정보를 가져옵니다.
STOMP 전용 시큐리티를 작성해 보안을 추가했습니다. (ws/는 여전히 permitall()입니다)
WebSocket 요청이기 때문에 기존의 FilterChain을 통과하지 않으며 대신
Interceptor에서 그 역할을 대신합니다.


#221  을 보완한 PR입니다. (해당 PR은 닫도록 하겠습니다)

---

> 참고사항

Postman애 해팅 (Auth)로 요청 새로 만들어두었습니다.
테스트 한 사항 : CONNECT > SEND
<img width="579" alt="스크린샷 2024-09-27 오후 12 38 12" src="https://github.com/user-attachments/assets/0d25a587-0f3f-4472-a5b3-e485111e5627">

