### PR TITLE
hotfix/chatroom-exit-unsubscribe-1: 기존에 DISCONNECT 했던 채팅방을 UNSUBSCRIBE로 퇴장을 구현함

### DIFF
--- a/src/main/java/com/dife/api/handler/DisconnectHandler.java
+++ b/src/main/java/com/dife/api/handler/DisconnectHandler.java
@@ -75,4 +75,13 @@ public class DisconnectHandler {
 		messagingTemplate.convertAndSend(
 				"/sub/chatroom/" + chatroomId, "Disconnect", accessor.getMessageHeaders());
 	}
+
+	public void unsubscribe(Long chatroomId, String sessionId)
+	{
+		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.UNSUBSCRIBE);
+		accessor.setSessionId(sessionId);
+		accessor.setDestination("/sub/chatroom/" + chatroomId);
+		messagingTemplate.convertAndSend(
+				"/sub/chatroom/" + chatroomId, "UNSUBSCRIBE", accessor.getMessageHeaders());
+	}
 }

--- a/src/main/java/com/dife/api/handler/DisconnectHandler.java
+++ b/src/main/java/com/dife/api/handler/DisconnectHandler.java
@@ -76,8 +76,7 @@ public class DisconnectHandler {
 				"/sub/chatroom/" + chatroomId, "Disconnect", accessor.getMessageHeaders());
 	}
 
-	public void unsubscribe(Long chatroomId, String sessionId)
-	{
+	public void unsubscribe(Long chatroomId, String sessionId) {
 		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.UNSUBSCRIBE);
 		accessor.setSessionId(sessionId);
 		accessor.setDestination("/sub/chatroom/" + chatroomId);

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -235,7 +235,7 @@ public class ChatService {
 		if (chatroom.getChatroomType() == GROUP) chatServiceFacade.decrease(chatroomId);
 
 		chatroom.getMembers().remove(member);
-		disconnectHandler.disconnect(chatroomId, sessionId);
+		disconnectHandler.unsubscribe(chatroomId, sessionId);
 
 		String exitMessage = member.getUsername() + "님이 퇴장하셨습니다!";
 		Chat chat = saveChat(member, chatroom, exitMessage);


### PR DESCRIPTION
#### 개요
기존에 DISCONNECT했던 방법인 STOMPHEADERACESSOR로 UNSUBSCRIBE를 진행해 구독 취소를 함

#### 테스트 확인사항
- 퇴장해도 세션 종료 안됨 확인
- 퇴장해도 멤버가 속한 다른 채팅방에 영향 안감 확인
- 퇴장 동작 확인 (채팅방 멤버 삭제)