### PR TITLE
 fix(error): 웹소켓 에러 시에 이유 함께 보낼 수 있도록 처리

### DIFF
--- a/src/main/java/com/dife/api/config/WebSockConfig.java
+++ b/src/main/java/com/dife/api/config/WebSockConfig.java
@@ -1,5 +1,6 @@
 package com.dife.api.config;
 
+import com.dife.api.exception.StompExceptionHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
@@ -11,11 +12,12 @@ import org.springframework.web.socket.config.annotation.*;
 @EnableWebSocketMessageBroker
 public class WebSockConfig implements WebSocketMessageBrokerConfigurer {
 
+	private final StompExceptionHandler stompExceptionHandler;
 	private final WebSocketInterceptor webSocketInterceptor;
 
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
-		registry.addEndpoint("/ws").setAllowedOrigins("*");
+		registry.setErrorHandler(stompExceptionHandler).addEndpoint("/ws").setAllowedOrigins("*");
 	}
 
 	@Override

--- a/src/main/java/com/dife/api/exception/StompExceptionHandler.java
+++ b/src/main/java/com/dife/api/exception/StompExceptionHandler.java
@@ -1,0 +1,78 @@
+package com.dife.api.exception;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler;
+
+@Component
+public class StompExceptionHandler extends StompSubProtocolErrorHandler {
+	private static final byte[] EMPTY_PAYLOAD = new byte[0];
+
+	public StompExceptionHandler() {
+		super();
+	}
+
+	@Override
+	public Message<byte[]> handleClientMessageProcessingError(
+			Message<byte[]> clientMessage, Throwable ex) {
+		final Throwable exception = converterThrowException(ex);
+		if (exception instanceof Exception) {
+			return handleUnauthorizedException(clientMessage, exception);
+		}
+		return super.handleClientMessageProcessingError(clientMessage, ex);
+	}
+
+	private Throwable converterThrowException(final Throwable exception) {
+		if (exception instanceof MessageDeliveryException) {
+			return exception.getCause();
+		}
+		return exception;
+	}
+
+	private Message<byte[]> handleUnauthorizedException(Message<byte[]> clientMessage, Throwable ex) {
+		return prepareErrorMessage(clientMessage, ex.getMessage(), HttpStatus.UNAUTHORIZED.name());
+	}
+
+	private Message<byte[]> prepareErrorMessage(
+			final Message<byte[]> clientMessage, final String message, final String errorCode) {
+		final StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.ERROR);
+		accessor.setMessage(errorCode);
+		accessor.setLeaveMutable(true);
+		setReceiptIdForClient(clientMessage, accessor);
+		return MessageBuilder.createMessage(
+				message != null ? message.getBytes(StandardCharsets.UTF_8) : EMPTY_PAYLOAD,
+				accessor.getMessageHeaders());
+	}
+
+	private void setReceiptIdForClient(
+			final Message<byte[]> clientMessage, final StompHeaderAccessor accessor) {
+		if (Objects.isNull(clientMessage)) {
+			return;
+		}
+
+		final StompHeaderAccessor clientHeaderAccessor =
+				MessageHeaderAccessor.getAccessor(clientMessage, StompHeaderAccessor.class);
+		final String receiptId =
+				Objects.isNull(clientHeaderAccessor) ? null : clientHeaderAccessor.getReceipt();
+		if (receiptId != null) {
+			accessor.setReceiptId(receiptId);
+		}
+	}
+
+	@Override
+	protected Message<byte[]> handleInternal(
+			StompHeaderAccessor errorHeaderAccessor,
+			byte[] errorPayload,
+			Throwable cause,
+			StompHeaderAccessor clientHeaderAccessor) {
+		return MessageBuilder.createMessage(errorPayload, errorHeaderAccessor.getMessageHeaders());
+	}
+}

--- a/src/main/java/com/dife/api/model/Member.java
+++ b/src/main/java/com/dife/api/model/Member.java
@@ -119,4 +119,17 @@ public class Member extends BaseTimeEntity {
 			inverseJoinColumns = @JoinColumn(name = "likelisted_member_id"))
 	@JsonIgnore
 	private List<Member> likeList = new ArrayList<>();
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Member member = (Member) o;
+		return Objects.equals(id, member.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id); // Use ID for hashing
+	}
 }

--- a/src/main/java/com/dife/api/service/ChatService.java
+++ b/src/main/java/com/dife/api/service/ChatService.java
@@ -50,6 +50,7 @@ public class ChatService {
 	private final BlockService blockService;
 	private final NotificationService notificationService;
 	private final ModelMapper modelMapper;
+	private final ChatroomService chatroomService;
 
 	public void sendMessage(
 			ChatRequestDto dto, SimpMessageHeaderAccessor headerAccessor, UserDetails userDetails)
@@ -135,11 +136,7 @@ public class ChatService {
 	public void chat(
 			ChatRequestDto dto, SimpMessageHeaderAccessor headerAccessor, UserDetails userDetails)
 			throws JsonProcessingException {
-
-		Chatroom chatroom =
-				chatroomRepository
-						.findById(dto.getChatroomId())
-						.orElseThrow(ChatroomNotFoundException::new);
+		Chatroom chatroom = chatroomService.getChatroomById(dto.getChatroomId());
 
 		String sessionId = headerAccessor.getSessionId();
 		String memberEmail = userDetails.getUsername();

--- a/src/main/java/com/dife/api/service/ChatroomService.java
+++ b/src/main/java/com/dife/api/service/ChatroomService.java
@@ -544,4 +544,12 @@ public class ChatroomService {
 		member.getChatrooms().remove(chatroom);
 		chatroom.getMembers().remove(member);
 	}
+
+	public Chatroom getChatroomById(Long id) {
+		return chatroomRepository.findById(id).orElseThrow(ChatroomNotFoundException::new);
+	}
+
+	public boolean isMemberInChatroom(Member member, Chatroom chatroom) {
+		return chatroom.getMembers().contains(member);
+	}
 }


### PR DESCRIPTION
### 개요

- 현재 웹소켓의 연결이 끊길 때 원인이 잘 나오지 않는 문제가 있다.
- 에러 발생 시, 원인을 전달하기 위해 StompSubProtocolHandler를 직접
작성한다.
- Interceptor에서 에러 체킹을 추가한다.

### 수정 사항

- 에러 발생 시, 원인을 전달하기 위해 StompSubProtocolHandler를 직접
  - 빠른 구현을 위해 링크 참고해서 일부만 수정함: https://velog.io/@jkijki12/%EC%B1%84%ED%8C%85-STOMP-JWT
- WebsocketInterceptor에서, JWT가 필요한 Command와 그렇지 않은
Command를 구분해서 알맞게 상황처리를 해준다.
  - CONNECT, SEND, MESSAGE, SUBSCRIBE는 JWT 필요
  - CONNECT의 경우에는 초기 auth 설정해줌
  - SUBSCRIBE의 경우에 destination 체킹 진행
  - SUBSCRIBE 때, 구독 권한이 있는지 확인한다.
- chatroom.getMembers().contains(member) 이 부분에서 Member 인스턴스가
달라도, id로 멤버가 포함되어있는지 체킹이 필요하기 때문에, equals와
hashcode 함께 override (Convention 따라, o 변수 사용)
