### PR TITLE
refactor/chat-exit-auth-1: 개선된 채팅 인증/인가 적용한 채팅방 퇴장 수정

### DIFF
--- a/src/main/java/com/dife/api/handler/DisconnectHandler.java
+++ b/src/main/java/com/dife/api/handler/DisconnectHandler.java
@@ -27,15 +27,6 @@ public class DisconnectHandler {
 		return true;
 	}
 
-	public boolean isExitDisconnectChecked(Chatroom chatroom, String sessionId) {
-
-		if (isEmpty(chatroom)) {
-			disconnect(chatroom.getId(), sessionId);
-			return false;
-		}
-		return true;
-	}
-
 	private boolean isValidGroupChatroom(Chatroom chatroom, String password) {
 		return isGroupChatroom(chatroom) && !isRestrictedGroupChatroom(chatroom, password);
 	}
@@ -74,13 +65,5 @@ public class DisconnectHandler {
 		accessor.setDestination("/sub/chatroom/" + chatroomId);
 		messagingTemplate.convertAndSend(
 				"/sub/chatroom/" + chatroomId, "Disconnect", accessor.getMessageHeaders());
-	}
-
-	public void unsubscribe(Long chatroomId, String sessionId) {
-		StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.UNSUBSCRIBE);
-		accessor.setSessionId(sessionId);
-		accessor.setDestination("/sub/chatroom/" + chatroomId);
-		messagingTemplate.convertAndSend(
-				"/sub/chatroom/" + chatroomId, "UNSUBSCRIBE", accessor.getMessageHeaders());
 	}
 }


### PR DESCRIPTION
### 개요 
- 기존에 채팅방 퇴장하면 DISCONNECT 했던 것을 UNSUBSCRIBE로 수정
-  messagingTemplate 이용해 UNSUBSCRIBE 메시지 직접 서버에서 전송
- 앞선 채팅방 인증 코드 merge 후에 merge 예정