### PR TITLE
Feat/chatroom re enter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	implementation 'org.springframework.security:spring-security-messaging'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -77,5 +76,6 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	jvmArgs '-Xmx2048m'
 	exclude '**/MemberControllerTest.*'
 }

--- a/src/main/java/com/dife/api/controller/SwaggerChatroomController.java
+++ b/src/main/java/com/dife/api/controller/SwaggerChatroomController.java
@@ -84,7 +84,7 @@ public interface SwaggerChatroomController {
 	@Operation(
 			summary = "채팅방 전체 조회 API",
 			description =
-					"조회하고자 하는 채팅방 타입(그룹/싱글)을 입력해 속한 채팅방들을 조회하는 API입니다. 그룹의 경우 그냥 GROUP만 입력값으로 넣고 싱글의 경우 SINGLE과 더불어 조회하고자 하는 상대방의 id를 입력값으로 넣어야 합니다.")
+					"조회하고자 하는 채팅방 타입(GROUP/SINGLE/EXITED/MANAGER)을 입력해 속한 채팅방들을 조회하는 API입니다. 그룹의 경우 그냥 GROUP만 입력값으로 넣고 싱글의 경우 SINGLE과 더불어 조회하고자 하는 상대방의 id를 입력값으로 넣어야 합니다.")
 	@ApiResponse(
 			responseCode = "200",
 			description = "채팅방 조회 성공 예시",

--- a/src/main/java/com/dife/api/model/Chatroom.java
+++ b/src/main/java/com/dife/api/model/Chatroom.java
@@ -47,6 +47,13 @@ public class Chatroom extends BaseTimeEntity {
 	@JsonIgnore
 	private Set<Member> members = new HashSet<>();
 
+	@ManyToMany(fetch = FetchType.EAGER)
+	@JoinTable(
+			name = "chatroom_exited_members",
+			joinColumns = @JoinColumn(name = "chatroom_id"),
+			inverseJoinColumns = @JoinColumn(name = "member_id"))
+	private Set<Member> exitedMembers = new HashSet<>();
+
 	@OneToMany(mappedBy = "chatroom", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
 	@JsonIgnore
 	private Set<Chat> chats = new HashSet<>();

--- a/src/main/java/com/dife/api/model/ChatroomType.java
+++ b/src/main/java/com/dife/api/model/ChatroomType.java
@@ -2,5 +2,7 @@ package com.dife.api.model;
 
 public enum ChatroomType {
 	GROUP,
-	SINGLE
+	SINGLE,
+	EXITED,
+	MANAGER
 }

--- a/src/main/java/com/dife/api/model/Member.java
+++ b/src/main/java/com/dife/api/model/Member.java
@@ -76,6 +76,10 @@ public class Member extends BaseTimeEntity {
 	@JsonIgnore
 	private Set<Chatroom> chatrooms = new HashSet<>();
 
+	@ManyToMany(mappedBy = "exitedMembers") // Chatroom 엔티티의 exitedMembers와 일치시킴
+	@JsonIgnore
+	private Set<Chatroom> exitedChatrooms = new HashSet<>();
+
 	@OneToMany(mappedBy = "manager")
 	@JsonIgnore
 	private Set<Chatroom> managingChatrooms = new HashSet<>();

--- a/src/main/java/com/dife/api/model/dto/ChatroomResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/ChatroomResponseDto.java
@@ -14,4 +14,6 @@ public interface ChatroomResponseDto {
 	ChatroomType getChatroomType();
 
 	Set<MemberRestrictedResponseDto> getMembers();
+
+	Set<MemberRestrictedResponseDto> getExitedMembers();
 }

--- a/src/main/java/com/dife/api/model/dto/GroupChatroomResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/GroupChatroomResponseDto.java
@@ -25,6 +25,8 @@ public class GroupChatroomResponseDto implements ChatroomResponseDto {
 
 	private Set<MemberRestrictedResponseDto> members = new HashSet<>();
 
+	private Set<MemberRestrictedResponseDto> exitedMembers = new HashSet<>();
+
 	private MemberRestrictedResponseDto manager;
 
 	private String name;

--- a/src/main/java/com/dife/api/model/dto/SingleChatroomResponseDto.java
+++ b/src/main/java/com/dife/api/model/dto/SingleChatroomResponseDto.java
@@ -23,5 +23,7 @@ public class SingleChatroomResponseDto implements ChatroomResponseDto {
 	@JsonProperty("chatroom_type")
 	private ChatroomType chatroomType;
 
+	private Set<MemberRestrictedResponseDto> exitedMembers = new HashSet<>();
+
 	private Set<MemberRestrictedResponseDto> members = new HashSet<>();
 }

--- a/src/main/resources/db/changelog/v1.0/v1.0.5.xml
+++ b/src/main/resources/db/changelog/v1.0/v1.0.5.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="add-exitedMembers-chatroom-relation-20241010-1900" author="suyeon">
+        <createTable tableName="chatroom_exited_members">
+            <column name="chatroom_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="member_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="chatroom_exited_members"
+                                 baseColumnNames="chatroom_id"
+                                 constraintName="FK_CHATROOM_EXITED_CHATROOM"
+                                 referencedTableName="chatroom"
+                                 referencedColumnNames="id"/>
+
+        <addForeignKeyConstraint baseTableName="chatroom_exited_members"
+                                 baseColumnNames="member_id"
+                                 constraintName="FK_CHATROOM_EXITED_MEMBER"
+                                 referencedTableName="member"
+                                 referencedColumnNames="id"/>
+
+        <addPrimaryKey tableName="chatroom_exited_members" columnNames="chatroom_id, member_id" constraintName="PK_CHATROOM_EXITED"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
### 개요
- 원래 있었던 채팅방을 사용해 퇴장 후 재입장 처리하자

#### 시나리오
- 채팅방 생성 -> 채팅방 CONNECT, SUBSCRIBE, SEND 후 EXIT -> notification, chat, chatroom_exited_member 입력 확인
- 퇴장한 유저가 다시 입장
`{"chatType":"ENTER", "chatroomId":1}`